### PR TITLE
Changed the configuration parameter from ssl_verify to verify_ssl

### DIFF
--- a/example/simple.rb
+++ b/example/simple.rb
@@ -5,7 +5,7 @@ conf = XClarityClient::Configuration.new(
   :password => '',
   :host     => '',
   :auth_type => '',
-  :ssl_verify => ''
+  :verify_ssl => ''
 )
 
 # virtual_appliance = XClarityClient::VirtualApplianceManagement.new(conf)


### PR DESCRIPTION
Summary:
Changed the configuration parameter from ssl_verify to verify_ssl

Description:
In commit "Naming env refactoring: from SSL_VERIFY to VERIFY_SSL" done on Oct 25 2016, the configuration parameter was changed. This was not reflected in the example/simple.rb. This commit is done to fix the same,