### PR TITLE
Connection url

### DIFF
--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -16,7 +16,11 @@ module XClarityClient
     def connection_builder(conf, uri)
       $lxca_log.info "XClarityClient::XClarityBase connection_builder", "Creating connection to #{conf.host + uri}" 
       #Building configuration
-      @conn = Faraday.new(url: conf.host + uri) do |faraday|
+      host = conf.host;
+      if !host.start_with?('https://') && !host.start_with?('http://')
+         host = 'https://' + host
+      end
+      @conn = Faraday.new(url: host + uri) do |faraday|
         faraday.request  :url_encoded             # form-encode POST params
         faraday.response :logger                  # log requests to STDOUT -- This line, should be uncommented if you wanna inspect the URL Request
         faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP

--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -6,7 +6,6 @@ module XClarityClient
   class XClarityBase
 
     token_auth = '/session'.freeze
-
     attr_reader :conn
     
     def initialize(conf, uri)
@@ -16,11 +15,11 @@ module XClarityClient
     def connection_builder(conf, uri)
       $lxca_log.info "XClarityClient::XClarityBase connection_builder", "Creating connection to #{conf.host + uri}" 
       #Building configuration
-      host = conf.host;
+      host = conf.host
       if !host.start_with?('https://') && !host.start_with?('http://')
-         host = 'https://' + host
+         host = "https://#{host}"
       end
-      @conn = Faraday.new(url: host + uri) do |faraday|
+      @conn = Faraday.new(:url => "#{host}#{uri}") do |faraday|
         faraday.request  :url_encoded             # form-encode POST params
         faraday.response :logger                  # log requests to STDOUT -- This line, should be uncommented if you wanna inspect the URL Request
         faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'apib/mock_server'
 require 'webmock/rspec'
 
 
-base_url = "http://example.com"
+base_url = "https://example.com"
 # These environment variables must be defined
 ENV['LXCA_USERNAME']   ||= ''
 ENV['LXCA_PASSWORD']   ||= ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,7 @@ require 'xclarity_client'
 require 'apib/mock_server'
 require 'webmock/rspec'
 
-
-base_url = "https://example.com"
+base_url = 'https://example.com'
 # These environment variables must be defined
 ENV['LXCA_USERNAME']   ||= ''
 ENV['LXCA_PASSWORD']   ||= ''
@@ -12,7 +11,7 @@ ENV['LXCA_HOST']       ||= base_url
 ENV['LXCA_AUTH_TYPE']  ||= ''
 ENV['LXCA_VERIFY_SSL'] ||= 'NONE'
 
-blueprints = ""
+blueprints = ''
 Dir.glob('docs/apib/*.apib') do |blueprint|
   blueprints << File.open(blueprint).read
 end

--- a/spec/xclarity_client_node_spec.rb
+++ b/spec/xclarity_client_node_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 describe XClarityClient do
   before :all do
-    WebMock.allow_net_connect! # -- This line should be uncommented if you're using external mock test
+    # -- The next line should be uncommented
+    # if you're using external mock test
+    WebMock.allow_net_connect!
 
     conf = XClarityClient::Configuration.new(
       username:   ENV['LXCA_USERNAME'],
       password:   ENV['LXCA_PASSWORD'],
-      host:       "example.com",
+      host:       'example.com',
       auth_type:  ENV['LXCA_AUTH_TYPE'],
       verify_ssl: ENV['LXCA_VERIFY_SSL']
     )
@@ -15,12 +17,12 @@ describe XClarityClient do
     @client = XClarityClient::Client.new(conf)
     @host = ENV['LXCA_HOST']
 
-    @includeAttributes = %w(accessState activationKeys)
-    @excludeAttributes = %w(accessState activationKeys)
+    @include_attributes = %w(access_state activation_keys)
+    @exclude_attributes = %w(access_state activation_keys)
   end
 
   before :each do
-    @uuidArray = @client.discover_nodes.map { |node| node.uuid  }
+    @uuid_array = @client.discover_nodes.map(&:uuid)
   end
 
   it 'has a version number' do
@@ -28,19 +30,17 @@ describe XClarityClient do
   end
 
   describe 'GET /nodes' do
-
     it 'should respond with an array' do
       expect(@client.discover_nodes.class).to eq(Array)
     end
-
   end
 
   describe 'GET /nodes/UUID' do
     context 'with include attributes' do
       it 'required attributes should not be nil' do
-        response = @client.fetch_nodes(@uuidArray, @includeAttributes,nil)
+        response = @client.fetch_nodes(@uuid_array, @include_attributes, nil)
         response.map do |node|
-          @includeAttributes.map do |attribute|
+          @include_attributes.map do |attribute|
             expect(node.send(attribute)).not_to be_nil
           end
         end
@@ -49,9 +49,9 @@ describe XClarityClient do
 
     context 'with excludeAttributes' do
       it 'excluded attributes should to be nil' do
-        response = @client.fetch_nodes(@uuidArray, nil, @excludeAttributes)
+        response = @client.fetch_nodes(@uuid_array, nil, @exclude_attributes)
         response.map do |node|
-          @excludeAttributes.map do |attribute|
+          @exclude_attributes.map do |attribute|
             expect(node.send(attribute)).to be_nil
           end
         end
@@ -60,12 +60,11 @@ describe XClarityClient do
   end
 
   describe 'GET /nodes/UUID,UUID,...,UUID' do
-
     context 'with includeAttributes' do
       it 'required attributes shoud not be nil ' do
-        response = @client.fetch_nodes(@uuidArray, @includeAttributes,nil)
+        response = @client.fetch_nodes(@uuid_array, @include_attributes, nil)
         response.map do |node|
-          @includeAttributes.map do |attribute|
+          @include_attributes.map do |attribute|
             expect(node.send(attribute)).not_to be_nil
           end
         end
@@ -74,9 +73,9 @@ describe XClarityClient do
 
     context 'with excludeAttributes' do
       it 'excluded attributes shoud to be nil' do
-        response = @client.fetch_nodes(@uuidArray, nil, @excludeAttributes)
+        response = @client.fetch_nodes(@uuid_array, nil, @exclude_attributes)
         response.map do |node|
-          @excludeAttributes.map do |attribute|
+          @exclude_attributes.map do |attribute|
             expect(node.send(attribute)).to be_nil
           end
         end
@@ -85,12 +84,11 @@ describe XClarityClient do
   end
 
   describe 'GET /nodes' do
-
     context 'with includeAttributes' do
       it 'required attributes should not be nil' do
-        response = @client.fetch_nodes(nil,@includeAttributes,nil)
+        response = @client.fetch_nodes(nil, @include_attributes, nil)
         response.first do |node|
-          @includeAttributes.map do |attribute|
+          @include_attributes.map do |attribute|
             expect(node.send(attribute)).not_to be_nil
           end
         end
@@ -99,9 +97,9 @@ describe XClarityClient do
 
     context 'with excludeAttributes' do
       it 'excluded attributes should be nil' do
-        response = @client.fetch_nodes(nil,nil,@excludeAttributes)
+        response = @client.fetch_nodes(nil, nil, @exclude_attributes)
         response.map do |node|
-          @excludeAttributes.map do |attribute|
+          @exclude_attributes.map do |attribute|
             expect(node.send(attribute)).to be_nil
           end
         end
@@ -111,9 +109,8 @@ describe XClarityClient do
 
   describe 'Get /node' do
     it 'should power down system' do
-      response = @client.power_off_node(@uuidArray[0])
+      response = @client.power_off_node(@uuid_array[0])
       expect(response.status).to eq(200)
-
     end
   end
 
@@ -121,28 +118,26 @@ describe XClarityClient do
     context 'with a leds object' do
       context 'with state == "On" and name == "Identify"' do
         it 'turns on the location led' do
-          @client.turn_on_loc_led(@uuidArray[0])
-          uri = "#{@host}/nodes/#{@uuidArray[0]}"
+          @client.turn_on_loc_led(@uuid_array[0])
+          uri = "#{@host}/nodes/#{@uuid_array[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'On' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made
         end
       end
-
       context 'with state == "Off" and name == "Identify"' do
         it 'turns off the location led' do
-          @client.turn_off_loc_led(@uuidArray[0])
-          uri = "#{@host}/nodes/#{@uuidArray[0]}"
+          @client.turn_off_loc_led(@uuid_array[0])
+          uri = "#{@host}/nodes/#{@uuid_array[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'Off' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made
         end
       end
-
       context 'with state == "Blinking" and name == "Identify"' do
         it 'turns on the blinking location led' do
-          @client.blink_loc_led(@uuidArray[0])
-          uri = "#{@host}/nodes/#{@uuidArray[0]}"
+          @client.blink_loc_led(@uuid_array[0])
+          uri = "#{@host}/nodes/#{@uuid_array[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'Blinking' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made

--- a/spec/xclarity_client_node_spec.rb
+++ b/spec/xclarity_client_node_spec.rb
@@ -9,7 +9,7 @@ describe XClarityClient do
     conf = XClarityClient::Configuration.new(
       username:   ENV['LXCA_USERNAME'],
       password:   ENV['LXCA_PASSWORD'],
-      host:       'example.com',
+      host:       ENV['LXCA_HOST'],
       auth_type:  ENV['LXCA_AUTH_TYPE'],
       verify_ssl: ENV['LXCA_VERIFY_SSL']
     )

--- a/spec/xclarity_client_node_spec.rb
+++ b/spec/xclarity_client_node_spec.rb
@@ -7,12 +7,13 @@ describe XClarityClient do
     conf = XClarityClient::Configuration.new(
       username:   ENV['LXCA_USERNAME'],
       password:   ENV['LXCA_PASSWORD'],
-      host:       ENV['LXCA_HOST'],
+      host:       "example.com",
       auth_type:  ENV['LXCA_AUTH_TYPE'],
       verify_ssl: ENV['LXCA_VERIFY_SSL']
     )
 
     @client = XClarityClient::Client.new(conf)
+    @host = ENV['LXCA_HOST']
 
     @includeAttributes = %w(accessState activationKeys)
     @excludeAttributes = %w(accessState activationKeys)
@@ -121,7 +122,7 @@ describe XClarityClient do
       context 'with state == "On" and name == "Identify"' do
         it 'turns on the location led' do
           @client.turn_on_loc_led(@uuidArray[0])
-          uri = "http://example.com/nodes/#{@uuidArray[0]}"
+          uri = "#{@host}/nodes/#{@uuidArray[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'On' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made
@@ -131,7 +132,7 @@ describe XClarityClient do
       context 'with state == "Off" and name == "Identify"' do
         it 'turns off the location led' do
           @client.turn_off_loc_led(@uuidArray[0])
-          uri = "http://example.com/nodes/#{@uuidArray[0]}"
+          uri = "#{@host}/nodes/#{@uuidArray[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'Off' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made
@@ -141,7 +142,7 @@ describe XClarityClient do
       context 'with state == "Blinking" and name == "Identify"' do
         it 'turns on the blinking location led' do
           @client.blink_loc_led(@uuidArray[0])
-          uri = "http://example.com/nodes/#{@uuidArray[0]}"
+          uri = "#{@host}/nodes/#{@uuidArray[0]}"
           request_body = { 'body' => { 'leds' => [{ 'name'  => 'Identify',
                                                     'state' => 'Blinking' }] } }
           expect(a_request(:put, uri).with(request_body)).to have_been_made


### PR DESCRIPTION
This PR is to resolve the issue that requires users to input   the URL of the form https://  when using the client.  This PR will look for https:// or http://  if neither is found it will prepend https:// to the provided hostname or IP address provided.   

This should also remove the requirement in ManageIQ to enter https://<ip> in the hostname field.

@miq_bot assign @walteraa 