### PR TITLE
Bug fix in the attribute manipulator

### DIFF
--- a/lib/xclarity_client/xclarity_resource.rb
+++ b/lib/xclarity_client/xclarity_resource.rb
@@ -4,7 +4,6 @@ module XClarityClient
       attributes.each do |key, value|
         begin
           value = value.gsub("\u0000", '') if value.is_a?(String)
-          key = key.gsub("-","_")
           send("#{key}=", value)
         rescue
           $log.warn("UNEXISTING ATTRIBUTES FOR #{self.class}: #{key}") unless defined?(Rails).nil?


### PR DESCRIPTION
This PR is a bug fix to xclarity_resource:

- We had a gsub that treat string, but we received a symbol.
- We don't need this anymore.