### PR TITLE
Fix the LXCA attributes pattern

### DIFF
--- a/lib/xclarity_client/xclarity_resource.rb
+++ b/lib/xclarity_client/xclarity_resource.rb
@@ -4,6 +4,7 @@ module XClarityClient
       attributes.each do |key, value|
         begin
           value = value.gsub("\u0000", '') if value.is_a?(String)
+          key = key.to_s.gsub("-","_")
           send("#{key}=", value)
         rescue
           $log.warn("UNEXISTING ATTRIBUTES FOR #{self.class}: #{key}") unless defined?(Rails).nil?


### PR DESCRIPTION
We will need the gsub removed. LXCA have attributes with "-" instead of "_".

We don't have problem now because the attributes not in use yet.