### PR TITLE
Adds additional power actions

### DIFF
--- a/docs/apib/node_bmc.apib
+++ b/docs/apib/node_bmc.apib
@@ -1,0 +1,15 @@
+FORMAT: 1A
+
+# XClarity Nodes
+
+# PUT /nodes/6B538D351B8211E193F65CF3FC6E4030/bmc
+
++ Response 200
+  {
+  }
++ Response 400
++ Response 401
++ Response 404
++ Response 409
++ Response 500
+

--- a/lib/xclarity_client.rb
+++ b/lib/xclarity_client.rb
@@ -6,10 +6,10 @@ module XClarityClient
 end
 
 require 'xclarity_client/configuration'
-require 'xclarity_client/client'
 require 'xclarity_client/xclarity_base'
 require 'xclarity_client/xclarity_resource'
 require 'xclarity_client/xclarity_management_mixin'
+require 'xclarity_client/xclarity_power_management_mixin'
 require 'xclarity_client/virtual_appliance_management'
 require 'xclarity_client/node'
 require 'xclarity_client/node_management'
@@ -34,3 +34,4 @@ require 'xclarity_client/cabinet_management'
 require 'xclarity_client/event'
 require 'xclarity_client/event_management'
 require 'xclarity_client/discover'
+require 'xclarity_client/client'

--- a/lib/xclarity_client/client.rb
+++ b/lib/xclarity_client/client.rb
@@ -1,5 +1,7 @@
 module XClarityClient
   class Client
+    include XClarityClient::PowerManagementMixin
+
     def initialize(connection)
       @connection = connection
     end
@@ -140,20 +142,6 @@ module XClarityClient
 
     def fetch_events(opts = {})
       EventManagement.new(@connection).get_object_with_opts(opts, Event)
-    end
-
-    def power_on_node(uuid = '')
-      NodeManagement.new(@connection).set_node_power_state(uuid, 'powerOn')
-    end
-
-    def power_off_node(uuid = '')
-      NodeManagement.new(@connection).set_node_power_state(uuid, 'powerOff')
-    end
-
-    def power_restart_node(uuid = '')
-      NodeManagement.new(@connection).set_node_power_state(uuid,
-                                                           'powerCycleSoftGrace'
-                                                          )
     end
 
     def blink_loc_led(uuid = '')

--- a/lib/xclarity_client/node_management.rb
+++ b/lib/xclarity_client/node_management.rb
@@ -1,7 +1,9 @@
 require 'json'
 require 'uuid'
 
+# XClarityClient module/namespace
 module XClarityClient
+  # Node Management class
   class NodeManagement < XClarityBase
     include XClarityClient::ManagementMixin
 
@@ -16,14 +18,23 @@ module XClarityClient
     def set_node_power_state(uuid, requested_state = nil)
       if [uuid, requested_state].any? { |item| item.nil? }
         error = 'Invalid target or power state requested'
-        $lxca_log.info 'XclarityClient::NodeManagement set_node_power_state', error
+        source = 'XClarity::NodeManagement set_node_power_state'
+        $lxca_log.info source, error
         raise ArgumentError, error
       end
 
-      power_request = JSON.generate(powerState: requested_state) 
-      response = do_put(Node::BASE_URI + '/' + uuid, power_request)
-      $lxca_log.info 'XclarityClient::NodeManagement set_node_power_state', "Power state action has been sent with request #{power_request}"
-      response
+      send_power_request(Node::BASE_URI + '/' + uuid, requested_state)
+    end
+
+    def set_bmc_power_state(uuid, requested_state = nil)
+      if [uuid, requested_state].any? { |item| item.nil? }
+        error = 'Invalid target or power state requested'
+        source = 'XClarity::NodeManagement set_bmc_power_state'
+        $lxca_log.info source, error
+        raise ArgumentError, error
+      end
+
+      send_power_request(Node::BASE_URI + '/' + uuid + '/bmc', requested_state)
     end
 
     def set_loc_led_state(uuid, state, name = 'Identify')
@@ -32,6 +43,16 @@ module XClarityClient
       $lxca_log.info "XclarityClient::ManagementMixin set_loc_led_state", "Loc led state action has been sent"
 
       do_put("#{Node::BASE_URI}/#{uuid}", request)
+    end
+
+    private
+
+    def send_power_request(uri, requested_state = nil)
+      power_request = JSON.generate(powerState: requested_state)
+      response = do_put(uri, power_request)
+      msg = 'Power state action has been sent with request #{power_request}'
+      $lxca_log.info "XclarityClient::NodeManagement set_node_power_state", msg
+      response
     end
   end
 end

--- a/lib/xclarity_client/node_management.rb
+++ b/lib/xclarity_client/node_management.rb
@@ -50,8 +50,9 @@ module XClarityClient
     def send_power_request(uri, requested_state = nil)
       power_request = JSON.generate(powerState: requested_state)
       response = do_put(uri, power_request)
-      msg = 'Power state action has been sent with request #{power_request}'
-      $lxca_log.info "XclarityClient::NodeManagement set_node_power_state", msg
+      msg = "Power state action has been sent with request #{power_request}"
+
+      $lxca_log.info 'XclarityClient::NodeManagement set_node_power_state', msg
       response
     end
   end

--- a/lib/xclarity_client/xclarity_power_management_mixin.rb
+++ b/lib/xclarity_client/xclarity_power_management_mixin.rb
@@ -1,0 +1,36 @@
+# Top Level Xclarity module
+module XClarityClient
+  # Power management mixin
+  module PowerManagementMixin
+    def power_on_node(uuid = '')
+      NodeManagement.new(@connection).set_node_power_state(uuid, :powerOn)
+    end
+
+    def power_off_node(uuid = '')
+      NodeManagement.new(@connection).set_node_power_state(uuid, :powerOff)
+    end
+
+    def power_off_node_now(uuid = '')
+      NodeManagement.new(@connection).set_node_power_state(uuid, :powerNMI)
+    end
+
+    def power_restart_node(uuid = '')
+      client = NodeManagement.new(@connection)
+      client.set_node_power_state(uuid, :powerCycleSoftGrace)
+    end
+
+    def power_restart_node_now(uuid = '')
+      client = NodeManagement.new(@connection)
+      client.set_node_power_state(uuid, :powerCycleSoft)
+    end
+
+    def power_restart_node_controller(uuid = '')
+      client = NodeManagement.new(@connection)
+      client.set_bmc_power_state(uuid, :restart)
+    end
+
+    def power_restart_node_to_setup(uuid = '')
+      NodeManagement.new(@connection).set_node_power_state(uuid, :bootToF1)
+    end
+  end
+end

--- a/spec/xclarity_client_node_spec.rb
+++ b/spec/xclarity_client_node_spec.rb
@@ -131,6 +131,34 @@ describe XClarityClient do
         expect(a_request(:put, uri).with(request_body)).to have_been_made
         expect(response.status).to eq(200)
       end
+      it 'should power down system now' do
+        response = @client.power_off_node_now(@uuid_array[0])
+        uri = "#{@host}/nodes/#{@uuid_array[0]}"
+        request_body = { 'body' => { 'powerState' => 'powerNMI' } }
+        expect(a_request(:put, uri).with(request_body)).to have_been_made
+        expect(response.status).to eq(200)
+      end
+      it 'should restart system now' do
+        response = @client.power_restart_node_now(@uuid_array[0])
+        uri = "#{@host}/nodes/#{@uuid_array[0]}"
+        request_body = { 'body' => { 'powerState' => 'powerCycleSoft' } }
+        expect(a_request(:put, uri).with(request_body)).to have_been_made
+        expect(response.status).to eq(200)
+      end
+      it 'should restart system management controller' do
+        response = @client.power_restart_node_controller(@uuid_array[0])
+        uri = "#{@host}/nodes/#{@uuid_array[0]}/bmc"
+        request_body = { 'body' => { 'powerState' => 'restart' } }
+        expect(a_request(:put, uri).with(request_body)).to have_been_made
+        expect(response.status).to eq(200)
+      end
+      it 'should restart system to F1 setup' do
+        response = @client.power_restart_node_to_setup(@uuid_array[0])
+        uri = "#{@host}/nodes/#{@uuid_array[0]}"
+        request_body = { 'body' => { 'powerState' => 'bootToF1' } }
+        expect(a_request(:put, uri).with(request_body)).to have_been_made
+        expect(response.status).to eq(200)
+      end
       it 'should throw exception' do
         expect { @client.power_off_node(nil) }.to raise_error(ArgumentError)
       end


### PR DESCRIPTION
Adds additional power actions for  restart now, power off now,  restart to F1 setup and restart the management controller.

Introduces a PowerManagement mixin to begin modularizing the client class. Moves power_ methods from client.rb to xclarity_power_management_mixin.rb.