### PR TITLE
Adds validation code using /sessions calls

### DIFF
--- a/docs/apib/sessions.apib
+++ b/docs/apib/sessions.apib
@@ -1,0 +1,25 @@
+FORMAT: 1A
+
+# Lenovo XClarity Management Console API
+
+# POST /sessions
+
++ Response 200 (application/json)
+
+  {
+    "response": {
+      "pwChangeRequired": false
+    },
+    "result":"success",
+    "messages" : [ 
+      {
+        "id": "FQHMSE",
+        "text": "The request completed successfully.",
+        "explanation": "",
+        "recovery": {
+          "text": "Information only. No action is required.",
+          "URL":""
+        }
+      }
+    ]
+  }  

--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -6,7 +6,7 @@ require 'uri/https'
 module XClarityClient
   class XClarityBase
 
-    token_auth = '/session'.freeze
+    token_auth = '/sessions'.freeze
     attr_reader :conn
     
     def initialize(conf, uri)
@@ -32,8 +32,11 @@ module XClarityClient
         faraday.ssl[:verify] = conf.verify_ssl == 'PEER'
       end
 
-      response = authentication(conf) unless conf.auth_type != 'token'
-      #TODO: What's to do with the response of authentication request?
+      response = conf.auth_type == 'token' ? true : authentication(conf)
+      if response == false 
+          raise Faraday::Error::ConnectionFailed, 'Unable to connect to endpoint.'
+      end
+
       @conn.basic_auth(conf.username, conf.password) if conf.auth_type == 'basic_auth'
       $lxca_log.info "XClarityClient::XclarityBase connection_builder", "Connection created Successfuly"
       @conn
@@ -67,7 +70,7 @@ module XClarityClient
 
     def authentication(conf)
       response = @conn.post do |request|
-        request.url '/session'
+        request.url '/sessions' 
         request.headers['Content-Type'] = 'application/json'
         request.body = {:UserId => conf.username,
                         :password => conf.password,
@@ -75,6 +78,7 @@ module XClarityClient
                         :maxLostHeartBeats => 3,
                         :csrf => conf.csrf_token}.to_json
       end
+      response.success?
     end
   end
 end


### PR DESCRIPTION
Update client to use the private authentication method.   This will require all new client connections to "log in" before executing any REST request to the endpoint.