### PR TITLE
Add discover request functionality. 

### DIFF
--- a/docs/apib/discover_request.apib
+++ b/docs/apib/discover_request.apib
@@ -1,0 +1,40 @@
+FORMAT: 1A
+
+# XClarity discoverRequest
+
+# Discovery request with job id 215 [/discoverRequest/jobs/215]
+
+## Retrieve [GET]
++ Response 200
+[{
+    "result": 100,
+    "storageList": [],
+    "rackswitchList": [],
+    "serverList": [],
+    "xhmcList": [],
+    "progress": 100.0,
+    "chassisList": []
+}]
+
++ Response 401
++ Response 404
++ Response 409
++ Response 500
+
+# Post a discovery request [/discoverRequest]
+
+## Monitor [POST]
++ Request (application/json)
+[
+  {
+    "ipAddresses" : [""]
+  }
+]
++ Response 200
+
++ Response 400
++ Response 401
++ Response 404
++ Response 409
++ Response 500
+

--- a/lib/xclarity_client.rb
+++ b/lib/xclarity_client.rb
@@ -54,4 +54,6 @@ require 'xclarity_client/error/connection_failed'
 require 'xclarity_client/error/connection_failed_unknown'
 require 'xclarity_client/error/connection_refused'
 require 'xclarity_client/error/hostname_unknown'
+require 'xclarity_client/discover_request'
+require 'xclarity_client/discover_request_management'
 

--- a/lib/xclarity_client/client.rb
+++ b/lib/xclarity_client/client.rb
@@ -278,5 +278,14 @@ module XClarityClient
     def validate_configuration
       XClarityBase.new(@connection, '/')
     end
+
+    def discover_manageable_devices(ip_addresses)
+      DiscoverRequestManagement.new(@connection).discover_manageable_devices(ip_addresses)
+    end
+
+    def monitor_discover_request(job_id)
+      DiscoverRequestManagement.new(@connection).monitor_discover_request(job_id)
+    end
+
   end
 end

--- a/lib/xclarity_client/discover_request.rb
+++ b/lib/xclarity_client/discover_request.rb
@@ -1,0 +1,15 @@
+module XClarityClient
+  class DiscoverRequest
+    include XClarityClient::Resource
+
+    BASE_URI = '/discoverRequest'.freeze
+    LIST_NAME = 'deviceList'.freeze
+
+    attr_accessor :result, :rackswitchList, :serverList, :xhmcList, :progress, :chassisList, :cmmDisplayName, :cmms, :displayName, :fruNumber, :hostname, :ipAddresses, :machineType, :managementPorts, :model, :name, :password, :recoveryPassword, :serialNumber, :status, :type, :username, :uuid, :enablePassword, :firmware, :os, :subType
+
+    def initialize(attributes)
+      build_resource(attributes)
+    end
+
+  end
+end

--- a/lib/xclarity_client/discover_request_management.rb
+++ b/lib/xclarity_client/discover_request_management.rb
@@ -1,0 +1,32 @@
+require 'json'
+
+module XClarityClient
+  class DiscoverRequestManagement < XClarityBase
+
+    include XClarityClient::ManagementMixin
+
+    def initialize(conf)
+      super(conf, DiscoverRequest::BASE_URI)
+    end
+
+    def discover_manageable_devices(ip_addresses)
+      postReq = JSON.generate(["ipAddresses":ip_addresses])
+      response = do_post(DiscoverRequest::BASE_URI, postReq)
+      response
+    end
+
+    def monitor_discover_request(job_id)
+      response = connection(DiscoverRequest::BASE_URI + "/jobs/" + job_id)
+      return [] unless response.success?
+
+      body = JSON.parse(response.body)
+
+      body = {DiscoverRequest::LIST_NAME => body} if body.is_a? Array
+      body = {DiscoverRequest::LIST_NAME => [body]} unless body.has_key? DiscoverRequest::LIST_NAME
+      body[DiscoverRequest::LIST_NAME].map do |resource_params|
+        DiscoverRequest.new resource_params
+      end
+    end
+
+  end
+end

--- a/lib/xclarity_client/discover_request_management.rb
+++ b/lib/xclarity_client/discover_request_management.rb
@@ -10,8 +10,8 @@ module XClarityClient
     end
 
     def discover_manageable_devices(ip_addresses)
-      postReq = JSON.generate([ipAddresses: ip_addresses])
-      response = do_post(DiscoverRequest::BASE_URI, postReq)
+      post_req = JSON.generate([ipAddresses: ip_addresses])
+      response = do_post(DiscoverRequest::BASE_URI, post_req)
       response
     end
 

--- a/lib/xclarity_client/discover_request_management.rb
+++ b/lib/xclarity_client/discover_request_management.rb
@@ -10,7 +10,7 @@ module XClarityClient
     end
 
     def discover_manageable_devices(ip_addresses)
-      postReq = JSON.generate(["ipAddresses":ip_addresses])
+      postReq = JSON.generate([ipAddresses: ip_addresses])
       response = do_post(DiscoverRequest::BASE_URI, postReq)
       response
     end

--- a/spec/xclarity_client_discover_request_spec.rb
+++ b/spec/xclarity_client_discover_request_spec.rb
@@ -11,11 +11,12 @@ describe XClarityClient do
     :host     => ENV['LXCA_HOST'],
     :port     => ENV['LXCA_PORT'],
     :auth_type => ENV['LXCA_AUTH_TYPE'],
-    :verify_ssl => ENV['LXCA_VERIFY_SSL']
+    :verify_ssl => ENV['LXCA_VERIFY_SSL'],
+    :user_agent_label => ENV['LXCA_USER_AGENT_LABEL']
     )
 
     @client = XClarityClient::Client.new(conf)
-
+    @user_agent = ENV['LXCA_USER_AGENT_LABEL']
     @host = ENV['LXCA_HOST']
   end
 
@@ -37,7 +38,8 @@ describe XClarityClient do
       it 'discovers all manageable devices for the given IP address array' do
         @client.discover_manageable_devices(["1.2.3.4"])
         uri = "#{@host}/discoverRequest"
-	expect(a_request(:post, uri).with(:body => '[{"ipAddresses":["1.2.3.4"]}]', :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'})).to have_been_made
+        user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
+	expect(a_request(:post, uri).with(:body => '[{"ipAddresses":["1.2.3.4"]}]', :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end

--- a/spec/xclarity_client_discover_request_spec.rb
+++ b/spec/xclarity_client_discover_request_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe XClarityClient do
+
+  before :all do
+    WebMock.allow_net_connect! #-- Uncomment this line if you're testing with a external mock.
+
+    conf = XClarityClient::Configuration.new(
+    :username => ENV['LXCA_USERNAME'],
+    :password => ENV['LXCA_PASSWORD'],
+    :host     => ENV['LXCA_HOST'],
+    :port     => ENV['LXCA_PORT'],
+    :auth_type => ENV['LXCA_AUTH_TYPE'],
+    :verify_ssl => ENV['LXCA_VERIFY_SSL']
+    )
+
+    @client = XClarityClient::Client.new(conf)
+
+    @host = ENV['LXCA_HOST']
+  end
+
+  it 'has a version number' do
+    expect(XClarityClient::VERSION).not_to be nil
+  end
+
+  describe 'GET /discoverRequest/jobs/job_ID' do
+    context 'monitor status of discover request' do
+      it 'should return an array' do
+        response = @client.monitor_discover_request('215')
+        expect(response).not_to be_empty
+      end
+    end
+  end
+
+  describe 'POST /discoverRequest' do
+    context 'discover manageable devices' do
+      it 'discovers all manageable devices for the given IP address array' do
+        @client.discover_manageable_devices(["1.2.3.4"])
+        uri = "#{@host}/discoverRequest"
+	expect(a_request(:post, uri).with(:body => '[{"ipAddresses":["1.2.3.4"]}]', :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'})).to have_been_made
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The following new functionalities are added:

a. POST on /discoverRequest to discover the manageable devices.
b. GET on /discoverRequest/jobs/<job_id> to monitor the status of a discovery request.