### PR TITLE
Fix the auth_type condition

### DIFF
--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -27,7 +27,7 @@ module XClarityClient
       @conn = Faraday.new(url: url) do |faraday|
         faraday.request  :url_encoded             # form-encode POST params
         faraday.response :logger                  # log requests to STDOUT -- This line, should be uncommented if you wanna inspect the URL Request
-        faraday.use :cookie_jar if conf.auth_type == 'validate'
+        faraday.use :cookie_jar if conf.auth_type == 'token'
         faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
         faraday.ssl[:verify] = conf.verify_ssl == 'PEER'
       end


### PR DESCRIPTION
This PR is able to:
- Fix the auth_type condition for use faraday_cookie_jar.

The problem is:  
- Again the manageiq-lenovo-provider will send the auth_type with the value as token or basic_auth.

reference: [PR 90](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/90) 