### PR TITLE
adding support to new attributes on 1.4 version

### DIFF
--- a/docs/apib/chassis.apib
+++ b/docs/apib/chassis.apib
@@ -32,6 +32,27 @@ FORMAT: 1A
 + Response 409
 + Response 500
 
+# GET /chassis/3B058C775CE44FA6AC05608B196EDAB1
+
++ Response 200 (application/json)
+
+{
+  "FQDN": "plugfest11.labs.lenovo.com",
+  "parent": {
+      "uuid": "E1C2D040-07F3-4DC1-84E6-3960F4F236FE",
+      "uri": "cabinet/E1C2D040-07F3-4DC1-84E6-3960F4F236FE"
+  },
+  "encapsulation": {
+        "encapsulationMode": "notSupported"
+  },
+  "securityDescriptor": {
+      "managedAuthEnabled": true,
+      "uri": "chassis/3B058C775CE44FA6AC05608B196EDAB1",
+      "managedAuthSupported": true
+  },
+  "powerCappingPolicy": {}
+}
+
 # GET /chassis/7F3E7E375B5747E0938969896B1CFDF5?includeAttributes=type
 
 + Response 200 (application/json)

--- a/docs/apib/jobs.apib
+++ b/docs/apib/jobs.apib
@@ -2,6 +2,14 @@ FORMAT: 1A
 
 # XClarity Jobs
 
+# GET /jobs/D5C0EC910776473997B2E2A5DD9171DE
+
++ Response 200 (application/json)
+{
+        "rebootPersistent": false,
+        "hidden": false
+}
+
 # Job with id 5 [/jobs/5]
 
 ## Retrieve [GET]
@@ -1225,7 +1233,7 @@ FORMAT: 1A
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
 }
-] 
+]
 + Response 400
 + Response 401
 + Response 404
@@ -2394,7 +2402,7 @@ FORMAT: 1A
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
 }
-] 
+]
 + Response 400
 + Response 401
 + Response 404
@@ -2419,7 +2427,7 @@ FORMAT: 1A
         "cancelURI": "",
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
-}, 
+},
 {
         "cancelledBy": "",
         "messageDisplay": "Manage job for 10.243.3.16",
@@ -2435,7 +2443,7 @@ FORMAT: 1A
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
 
-}, 
+},
 {
         "cancelledBy": "",
         "messageDisplay": "Manage job for 10.243.3.16",
@@ -2451,7 +2459,7 @@ FORMAT: 1A
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
 }
-] 
+]
 
 + Response 400
 + Response 401
@@ -3620,7 +3628,7 @@ FORMAT: 1A
         "uuid": "FEE5C5988F23453F8367597C3561DC54",
         "typeId": -1
 }
-] 
+]
 + Response 400
 + Response 401
 + Response 404

--- a/docs/apib/node.apib
+++ b/docs/apib/node.apib
@@ -2,6 +2,28 @@ FORMAT: 1A
 
 # XClarity Nodes
 
+# GET /nodes/5D3237D000A711E787D30894EF3C1E99
+
++ Response 200
+
+{
+"primary": true,
+    "securityDescriptor": {
+        "managedAuthEnabled": true,
+        "uri": "nodes/5D3237D000A711E787D30894EF3C1E99",
+        "managedAuthSupported": true
+    },
+    "FeaturesOnDemand": {
+    "tierLevel": 3,
+    "features": [
+        "RDOC",
+        "REMOTE CONTROL 6 USERS",
+        "REMOTE MEDIA"
+    ]
+    },
+    "logicalID": 1
+}
+
 # GET /nodes/6B538D351B8211E193F65CF3FC6E4030?includeAttributes=accessState,activationKeys
 
 + Response 200

--- a/docs/apib/switches.apib
+++ b/docs/apib/switches.apib
@@ -500,6 +500,70 @@ FORMAT: 1A
 + Response 409
 + Response 500
 
+# GET /switches/F5710BE70F223D8C91D74D9161159617
+
++ Response 200 (application/json)
+{
+  "ntpPushEnabled": false,
+  "ntpPushFrequency": 17,
+  "location": {
+      "lowestRackUnit": 0,
+      "location": "",
+      "rack": "",
+      "room": ""
+  },
+  "height": 1,
+  "memoryUtilization": "15.2%(Total : 4186705920 B, Free : 3546865664 B)",
+  "mgmtProcIPaddress": "10.243.14.96",
+  "temperatureSensors": [
+      {
+          "sensorName": "Sensor 1",
+          "sensorState": " 36.0 C"
+      }
+  ],
+  "entitleSerialNumber": "J11D32E",
+  "manufacturingDate": "17/11",
+  "panicDump": "No",
+  "powerSupply": "Power Supply 1: on;Power Supply 2: Off.",
+  "stackRole": "none",
+  "fans": [
+      {
+          "fanName": "Fan 1",
+          "fanSpeed": " 4326 RPM (63 PWM)",
+          "fanState": "Fans are in Front-To-Back AirFlow, Warning at 85 C and Recover at 95 C\r\n"
+      }
+  ],
+  "contact": "",
+  "sysObjectID": "1.3.6.1.4.1.19046.1.7.24",
+  "savePending": "No",
+  "resetReason": "1",
+  "applyPending": "No",
+  "OS": "ENOS",
+  "cpuUtilization": "9%",
+  "ports": [
+      {
+          "port": "1",
+          "configuredStatus": "up",
+          "PVID": "1",
+          "tagPVID": "untagged",
+          "peerMacAddress": "",
+          "portSpeed": "any",
+          "interfaceIndex": "129",
+          "vLAN": "untagged",
+          "portState": "down",
+          "portName": "",
+          "operationalStatus": "notPresent"
+      }
+  ],
+  "upTime": "6 days, 22:02:48.00"
+}
+
++ Response 200 (application/json)
+{
+        "rebootPersistent": false,
+        "hidden": false
+}
+
 # GET /switches/1B33D6D13F267A614567A897DC784F00,2BB054971DD2B201663F0027F8870F10,1B33D6CE6D58C30145BA0817F4B11400?includeAttributes=accessState,attachedNodes
 
 + Response 200 (application/json)

--- a/lib/xclarity_client/chassi.rb
+++ b/lib/xclarity_client/chassi.rb
@@ -11,14 +11,15 @@ module XClarityClient
                   :energyPolicies, :errorFields, :excludedHealthState, :fanMuxes,
                   :fanMuxSlots, :fans, :fanSlots, :fruNumber, :height, :hostname,
                   :ipAddresses, :isConnectionTrusted, :ledCardSlots, :leds,
-                  :location, :machineType, :managementPorts, :managerName, 
+                  :location, :machineType, :managementPorts, :managerName,
                   :managerUuid, :manufacturer, :manufacturerId, :mgmtProcIPaddress,
-                  :mmSlots, :model, :name, :nist, :nodes, :overallHealthState, 
+                  :mmSlots, :model, :name, :nist, :nodes, :overallHealthState,
                   :partNumber, :passThroughModules, :password, :posID,
                   :powerAllocation, :powerSupplies, :powerSupplySlots, :productId,
                   :productName, :recoveryPassword, :SecurityPolicy, :serialNumber,
                   :status, :switches, :switchSlots, :tlsVersion, :type, :uri,
-                  :userDescription, :username, :uuid, :vpdID
+                  :userDescription, :username, :uuid, :vpdID, :FQDN, :parent, :encapsulation,
+                  :securityDescriptor, :powerCappingPolicy
 
     def initialize(attributes)
       build_resource(attributes)

--- a/lib/xclarity_client/event.rb
+++ b/lib/xclarity_client/event.rb
@@ -6,8 +6,8 @@ module XClarityClient
     LIST_NAME = 'eventList'.freeze
 
     attr_accessor :action, :args, :bayText, :chassisText, :cn, :commonEventID, :componentID,
-                  :eventClass, :eventDate, :eventID, :eventSourceText, :failFRUs, :failSNs,
-                  :flags, :fruSerialNumberText, :localLogID, :localLogSequence, :location,
+                  :componentIdentifierText, :eventClass, :eventDate, :eventID, :eventSourceText, :failFRUs,
+                  :failSNs, :flags, :fruSerialNumberText, :localLogID, :localLogSequence, :location,
                   :msg, :msgID, :mtm, :originatorUUID, :parameters, :senderUUID, :serialnum,
                   :service, :serviceabilityText, :severity, :severityText, :sourceID,
                   :sourceLogID, :sourceLogSequence, :systemFruNumberText, :systemName,

--- a/lib/xclarity_client/job.rb
+++ b/lib/xclarity_client/job.rb
@@ -6,7 +6,8 @@ module XClarityClient
     LIST_NAME = 'jobsList'.freeze
 
     attr_accessor :status, :cancelledBy, :createdBy, :category, :typeId, :messageDisplay, :cancelURI,
-    :messageParameters, :startTime, :messageID, :messageBundle, :endTime, :id, :isCancelable, :uuid
+    :messageParameters, :startTime, :messageID, :messageBundle, :endTime, :id, :isCancelable, :rebootPersistent,
+    :uuid, :hidden
 
     def initialize(attributes)
       build_resource(attributes)

--- a/lib/xclarity_client/node.rb
+++ b/lib/xclarity_client/node.rb
@@ -16,7 +16,8 @@ module XClarityClient
                   :parentComplexID, :parentPartitionUUID, :partitionEnabled, :partitionID, :partNumber, :password, :pciCapabilities, :pciDevices, :physicalID, :ports,
                   :posID, :powerAllocation, :powerCappingPolicy, :powerStatus, :powerSupplies, :processors, :processorSlots, :productId, :productName, :raidSettings,
                   :recoveryPassword, :secureBootMode, :serialNumber, :server_type, :slots, :status, :subSlots, :subType, :thinkServerFru, :tlsVersion, :type, :uri,
-                  :userDescription, :username, :uuid, :vnicMode, :vpdID
+                  :userDescription, :username, :uuid, :vnicMode, :vpdID, :securityDescriptor, :primary, :logicalID, :FeaturesOnDemand,
+                  :canisterSlots, :canisters
 
     def initialize(attributes)
       build_resource(attributes)

--- a/lib/xclarity_client/scalable_complex.rb
+++ b/lib/xclarity_client/scalable_complex.rb
@@ -3,11 +3,10 @@ module XClarityClient
     include XClarityClient::Resource
 
     BASE_URI = '/scalableComplex'.freeze
-    LIST_NAME = 'complex'.freeze
+    LIST_NAME = ['complex', 'complexList'].freeze
 
     attr_accessor :complexID, :location, :nodeCount, :orphanNodes,
                   :partition, :partitionCount, :uuid
-
 
     def initialize(attributes)
       build_resource(attributes)

--- a/lib/xclarity_client/switch.rb
+++ b/lib/xclarity_client/switch.rb
@@ -11,7 +11,11 @@ module XClarityClient
                   :ipv6Addresses, :leds, :macAddresses, :machineType, :manufacturer, :manufacturerId,
                   :model, :name, :overallHealthState, :parent, :partNumber, :posID, :powerAllocation,
                   :powerState, :productId, :productName, :protectedMode, :serialNumber, :slots,
-                  :stackMode, :type, :uri, :userDescription, :uuid, :vpdID
+                  :stackMode, :type, :uri, :userDescription, :uuid, :vpdID, :ntpPushEnabled,
+                  :ntpPushFrequency, :location, :height, :memoryUtilization, :mgmtProcIPaddress,
+                  :temperatureSensors, :entitleSerialNumber, :manufacturingDate, :panicDump,
+                  :powerSupply, :stackRole, :fans, :contact, :sysObjectID, :savePending, :resetReason,
+                  :applyPending, :OS, :cpuUtilization, :ports, :upTime
 
     def initialize(attributes)
       build_resource(attributes)

--- a/spec/xclarity_client_chassi_spec.rb
+++ b/spec/xclarity_client_chassi_spec.rb
@@ -57,6 +57,20 @@ describe XClarityClient do
         end
       end
     end
+
+    context 'attributes included in the version 1.4' do
+      it 'getting new attributes' do
+        uuid = "3B058C775CE44FA6AC05608B196EDAB1"
+        response = @client.fetch_chassis([uuid])
+        response.each do |chassi|
+          chassi.FQDN.should_not be_nil
+          chassi.parent.should_not be_nil
+          chassi.encapsulation.should_not be_nil
+          chassi.securityDescriptor.should_not be_nil
+          chassi.powerCappingPolicy.should_not be_nil
+        end
+      end
+    end
   end
 
   describe 'GET /chassis/UUID,UUID,...,UUID' do

--- a/spec/xclarity_client_jobs_spec.rb
+++ b/spec/xclarity_client_jobs_spec.rb
@@ -40,7 +40,7 @@ describe XClarityClient do
         expect(@client.discover_jobs({"uuid":"FEE5C5988F23453F8367597C3561DC54"})).not_to be_empty
       end
     end
-    
+
     context 'with option state' do
       it 'should return an array' do
         expect(@client.discover_jobs({"state":"Stopped_With_Error"})).not_to be_empty
@@ -92,6 +92,17 @@ describe XClarityClient do
         response.map do |job|
           @includeAttributes.map do |attribute|
             expect(job.send(attribute)).not_to be_nil
+          end
+        end
+      end
+
+      context 'attributes included in the version 1.4' do
+        it 'getting new attributes' do
+          uuid = "D5C0EC910776473997B2E2A5DD9171DE"
+          response = @client.fetch_jobs([uuid])
+          response.each do |job|
+            job.rebootPersistent.should_not be_nil
+            job.hidden.should_not be_nil
           end
         end
       end

--- a/spec/xclarity_client_node_spec.rb
+++ b/spec/xclarity_client_node_spec.rb
@@ -58,6 +58,19 @@ describe XClarityClient do
         end
       end
     end
+
+    context 'attributes included in the version 1.4' do
+      it 'getting new attributes' do
+        uuid = "5D3237D000A711E787D30894EF3C1E99"
+        response = @client.fetch_nodes([uuid])
+        response.each do |node|
+          node.securityDescriptor.should_not be_nil
+          node.primary.should_not be_nil
+          node.logicalID.should_not be_nil
+          node.FeaturesOnDemand.should_not be_nil
+        end
+      end
+    end
   end
 
   describe 'GET /nodes/UUID,UUID,...,UUID' do

--- a/spec/xclarity_client_switch_spec.rb
+++ b/spec/xclarity_client_switch_spec.rb
@@ -94,4 +94,37 @@ describe XClarityClient do
       end
     end
   end
+
+  describe 'GET /switches/UUID' do
+    context 'attributes included in the version 1.4' do
+      it 'getting new attributes' do
+        uuid = "F5710BE70F223D8C91D74D9161159617"
+        response = @client.fetch_switches([uuid])
+        response.each do |switch|
+          switch.ntpPushEnabled.should_not be_nil
+          switch.ntpPushFrequency.should_not be_nil
+          switch.location.should_not be_nil
+          switch.height.should_not be_nil
+          switch.memoryUtilization.should_not be_nil
+          switch.mgmtProcIPaddress.should_not be_nil
+          switch.temperatureSensors.should_not be_nil
+          switch.entitleSerialNumber.should_not be_nil
+          switch.manufacturingDate.should_not be_nil
+          switch.panicDump.should_not be_nil
+          switch.powerSupply.should_not be_nil
+          switch.stackRole.should_not be_nil
+          switch.fans.should_not be_nil
+          switch.contact.should_not be_nil
+          switch.sysObjectID.should_not be_nil
+          switch.savePending.should_not be_nil
+          switch.resetReason.should_not be_nil
+          switch.applyPending.should_not be_nil
+          switch.OS.should_not be_nil
+          switch.cpuUtilization.should_not be_nil
+          switch.ports.should_not be_nil
+          switch.upTime.should_not be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is able to:
- Map the new attributes adds on the version 1.4;
- Add specs for test the parse of the new attributes;
- Refactor the strategy to handle lists from the API, to support list names that was changed in the new version.