### PR TITLE
Adding new attibutes of scalable_complex entity appended on API version 1.4

### DIFF
--- a/lib/xclarity_client/scalable_complex.rb
+++ b/lib/xclarity_client/scalable_complex.rb
@@ -3,11 +3,10 @@ module XClarityClient
     include XClarityClient::Resource
 
     BASE_URI = '/scalableComplex'.freeze
-    LIST_NAME = 'complex'.freeze
+    LIST_NAME = ['complex', 'complexList'].map { |name| name.freeze }.freeze
 
     attr_accessor :complexID, :location, :nodeCount, :orphanNodes,
                   :partition, :partitionCount, :uuid
-
 
     def initialize(attributes)
       build_resource(attributes)

--- a/lib/xclarity_client/xclarity_management_mixin.rb
+++ b/lib/xclarity_client/xclarity_management_mixin.rb
@@ -6,7 +6,7 @@ module XClarityClient
       response = connection(resource::BASE_URI, opts)
 
       $lxca_log.info "XclarityClient::ManagementMixin get_all_resources", "Response received from #{resource::BASE_URI}"
-      
+
       return [] unless response.success?
 
       body = JSON.parse(response.body)
@@ -14,9 +14,9 @@ module XClarityClient
         body = body['response']
       end
 
-      body = {resource::LIST_NAME => body} if body.is_a? Array
-      body = {resource::LIST_NAME => [body]} unless body.has_key? resource::LIST_NAME
-      body[resource::LIST_NAME].map do |resource_params|
+      list_name, body = add_listname_on_body(resource, body)
+
+      body[list_name].map do |resource_params|
         resource.new resource_params
       end
     end
@@ -146,6 +146,45 @@ module XClarityClient
       body[resource::LIST_NAME].map do |resource_params|
         resource.new resource_params
       end
+    end
+
+    private
+
+    # Process the response body to make sure that its contains the list name defined on resource
+    # Returns the list name present on body and the body itself
+    def add_listname_on_body(resource, body)
+      body.kind_of?(Array) ? process_body_as_array(resource, body) : process_body_as_hash(resource, body)
+    end
+
+    # Return any listname described on resource
+    def any_listname_of(resource)
+      if resource::LIST_NAME.kind_of?(Array)
+        resource::LIST_NAME.first # If is an array, any listname can be use
+      else
+        resource::LIST_NAME # If is not an array, just return the listname of resource
+      end
+    end
+
+    # Returns the body value assigned to the list name defined on resource
+    def process_body_as_array(resource, body)
+      list_name = any_listname_of(resource)
+
+      return list_name, { list_name => body } # assign the list name to the body
+    end
+
+    # Discover what list name defined on resource is present on body
+    # If none of then is find assume that the body is a single resource
+    # and add it value into array and assing to any list name
+    def process_body_as_hash(resource, body)
+      result = body
+
+      if resource::LIST_NAME.kind_of? Array # search which list name is present on body
+        list_name = resource::LIST_NAME.find { |name| body.keys.include?(name) && body[name].kind_of?(Array) }
+      else
+        list_name = any_listname_of(resource)
+      end
+      result = {list_name => [body]} unless body.has_key? list_name # for the cases where body represents a single resource
+      return list_name, result
     end
   end
 end


### PR DESCRIPTION
This PR is able to:
- Add new attributes to scalable_complex resource appended on LXCA API version 1.4;
- Refactor the strategy to get list names, for the cases where the list name changed in a new version. Basically it adds the possibility to provide more than one list name and the system will look if some of those names exists on response body.
