### PR TITLE
Adding new attibutes of event entity appended on API version 1.4

### DIFF
--- a/lib/xclarity_client/event.rb
+++ b/lib/xclarity_client/event.rb
@@ -6,8 +6,8 @@ module XClarityClient
     LIST_NAME = 'eventList'.freeze
 
     attr_accessor :action, :args, :bayText, :chassisText, :cn, :commonEventID, :componentID,
-                  :eventClass, :eventDate, :eventID, :eventSourceText, :failFRUs, :failSNs,
-                  :flags, :fruSerialNumberText, :localLogID, :localLogSequence, :location,
+                  :componentIdentifierText, :eventClass, :eventDate, :eventID, :eventSourceText, :failFRUs,
+                  :failSNs, :flags, :fruSerialNumberText, :localLogID, :localLogSequence, :location,
                   :msg, :msgID, :mtm, :originatorUUID, :parameters, :senderUUID, :serialnum,
                   :service, :serviceabilityText, :severity, :severityText, :sourceID,
                   :sourceLogID, :sourceLogSequence, :systemFruNumberText, :systemName,


### PR DESCRIPTION
This PR is able to:
- Add new attributes to events resource appended on LXCA API version 1.4