### PR TITLE
Adding new attibutes of chassis entity appended on API version 2.0

### DIFF
--- a/lib/xclarity_client/chassi.rb
+++ b/lib/xclarity_client/chassi.rb
@@ -18,8 +18,7 @@ module XClarityClient
                   :powerAllocation, :powerSupplies, :powerSupplySlots, :productId,
                   :productName, :recoveryPassword, :SecurityPolicy, :serialNumber,
                   :status, :switches, :switchSlots, :tlsVersion, :type, :uri,
-                  :userDescription, :username, :uuid, :vpdID, :FQDN, :parent, :encapsulation,
-                  :securityDescriptor, :powerCappingPolicy
+                  :userDescription, :username, :uuid, :vpdID, :securityDescriptor
 
     def initialize(attributes)
       build_resource(attributes)


### PR DESCRIPTION
This PR is able to:

- Add new attributes to Chassis resource appended on LXCA API version 2.0