### PR TITLE
Adding new attibutes of config_profile entity appended on LXCA API version 2.0

### DIFF
--- a/lib/xclarity_client/config_profile.rb
+++ b/lib/xclarity_client/config_profile.rb
@@ -7,8 +7,10 @@ module XClarityClient
 
     attr_accessor :identifier, :items, :label, :profileName, :serverName, :uuid, :chassisName, :bayId,
     :subBayId, :profileStatus, :templateName, :templateId, :type, :id, :externalId, :managementPatternPresent,
-    :addressPresent, :rackId, :unit, :ID, :name, :displayName, :displayId, :endPointType, :endPointId, 
-    :profilePath, :forScalableSecondaryNode, :secondaryProfileIDs, :serverTemplateId, :commands, :dynamicProperties, :primaryProfileID, :forScalableNode, :forScalablePrimaryNode, :deviceId, :deviceType, :managementPatternPresent, :rackID, :templateID
+    :addressPresent, :rackId, :unit, :ID, :name, :displayName, :displayId, :endPointType, :endPointId,
+    :profilePath, :forScalableSecondaryNode, :secondaryProfileIDs, :serverTemplateId, :commands, :dynamicProperties,
+    :primaryProfileID, :forScalableNode, :forScalablePrimaryNode, :deviceId, :deviceType, :managementPatternPresent,
+    :rackID, :templateID, :complianceStatus
 
     def initialize(attributes)
       build_resource(attributes)


### PR DESCRIPTION
This PR is able to:
- Add new attibutes of config_profile entity appended on LXCA API version 2.0