### PR TITLE
Adding new attibutes of event entity appended on LXCA API version 2.0

### DIFF
--- a/lib/xclarity_client/event.rb
+++ b/lib/xclarity_client/event.rb
@@ -12,7 +12,8 @@ module XClarityClient
                   :service, :serviceabilityText, :severity, :severityText, :sourceID,
                   :sourceLogID, :sourceLogSequence, :systemFruNumberText, :systemName,
                   :systemSerialNumberText, :systemText, :systemTypeModelText, :systemTypeText,
-                  :timeStamp, :typeText, :userid, :userIDIndex
+                  :timeStamp, :typeText, :userid, :userIDIndex, :descriptionArgs, :userActionArgs, :failFRUNames,
+                  :failFRUUUIDs, :failFRUPartNumbers
 
     def initialize(attributes)
       build_resource(attributes)


### PR DESCRIPTION
This PR is able to:
- Add new attibutes of event entity appended on LXCA API version 2.0