### PR TITLE
Adding new attibutes of node entity appended on LXCA API version 2.0

### DIFF
--- a/lib/xclarity_client/node.rb
+++ b/lib/xclarity_client/node.rb
@@ -17,7 +17,7 @@ module XClarityClient
                   :posID, :powerAllocation, :powerCappingPolicy, :powerStatus, :powerSupplies, :processors, :processorSlots, :productId, :productName, :raidSettings,
                   :recoveryPassword, :secureBootMode, :serialNumber, :server_type, :slots, :status, :subSlots, :subType, :thinkServerFru, :tlsVersion, :type, :uri,
                   :userDescription, :username, :uuid, :vnicMode, :vpdID, :securityDescriptor, :primary, :logicalID, :FeaturesOnDemand,
-                  :canisterSlots, :canisters
+                  :canisterSlots, :canisters, :userDefinedName, :management_processor_type
 
     def initialize(attributes)
       build_resource(attributes)


### PR DESCRIPTION
This PR is able to:
- Add new attibutes of node entity appended on LXCA API version 2.0