### PR TITLE
[DEPENDS_ON: 91, 94] Creating an Abstract Class for Services to centralize some operations

### DIFF
--- a/lib/xclarity_client.rb
+++ b/lib/xclarity_client.rb
@@ -15,5 +15,5 @@ require 'xclarity_client/xclarity_credentials_validator'
 require 'xclarity_client/discover'
 require 'xclarity_client/client'
 
-require 'xclarity_client/services/services'
 require 'xclarity_client/endpoints/endpoints'
+require 'xclarity_client/services/services'

--- a/lib/xclarity_client/connection/connection.rb
+++ b/lib/xclarity_client/connection/connection.rb
@@ -1,0 +1,102 @@
+require 'faraday'
+require 'faraday-cookie_jar'
+require 'uri'
+require 'uri/https'
+
+module XClarityClient
+  #
+  # TODO: doc this
+  #
+  class Connection
+    #
+    # TODO: doc this
+    #
+    def initialize(configuration)
+      @connection = build(configuration)
+    end
+
+    #
+    # TODO: doc this
+    #
+    def do_get(uri = "", query = "")
+      url_query = query.size > 0 ? "?" + query.map {|k, v| "#{k}=#{v}"}.join(",") : ""
+      @connection.get(uri + url_query)
+    rescue Faraday::Error::ConnectionFailed => e
+      $lxca_log.error "XClarityClient::XclarityBase connection", "Error trying to send a GET to #{uri + url_query}"
+      Faraday::Response.new
+    end
+
+    #
+    # TODO: doc this
+    #
+    def do_post(uri = "", body = "")
+      @connection.post do |req|
+        req.url uri
+        req.headers['Content-Type'] = 'application/json'
+        req.body = body
+      end
+    rescue Faraday::Error::ConnectionFailed => e
+      $lxca_log.error "XClarityClient::XclarityBase do_post", "Error trying to send a POST to #{uri}"
+      $lxca_log.error "XClarityClient::XclarityBase do_post", "Request sent: #{body}"
+      Faraday::Response.new
+    end
+
+    #
+    # TODO: doc this
+    #
+    def do_put(uri = "", body = "")
+      @connection.put do |req|
+        req.url uri
+        req.headers['Content-Type'] = 'application/json'
+        req.body = body
+      end
+    rescue Faraday::Error::ConnectionFailed => e
+      $lxca_log.error "XClarityClient::XclarityBase do_put", "Error trying to send a PUT to #{uri}"
+      $lxca_log.error "XClarityClient::XclarityBase do_put", "Request sent: #{body}"
+      Faraday::Response.new
+    end
+
+    #
+    # TODO: doc this
+    #
+    def do_delete(uri = "")
+      @connection.delete do |req|
+        req.url uri
+        req.headers['Content-Type'] = 'application/json'
+      end
+    end
+
+    private
+
+    #
+    # TODO: doc this
+    #
+    def build(configuration)
+      $lxca_log.info "XClarityClient::Connection build", "Building the connection"
+
+      hostname = URI.parse(configuration.host)
+
+      url = URI::HTTPS.build({ :host     => hostname.scheme ? hostname.host : hostname.path,
+                               :port     => configuration.port.to_i,
+                               :query    => hostname.query,
+                               :fragment => hostname.fragment }).to_s
+
+      $lxca_log.info "XClarityClient::XClarityBase connection_builder", "Creating connection to #{url}"
+
+      connection = Faraday.new(url: url) do |faraday|
+        faraday.request        :url_encoded             # form-encode POST params
+        faraday.response       :logger, $lxca_log.log   # log requests to STDOUT -- This line, should be uncommented if you wanna inspect the URL Request
+        faraday.use            :cookie_jar if configuration.auth_type == 'token'
+        faraday.adapter        Faraday.default_adapter  # make requests with Net::HTTP
+        faraday.ssl[:verify] = configuration.verify_ssl == 'PEER'
+      end
+
+      connection.headers[:user_agent] = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (configuration.user_agent_label.nil? ? "" : " (#{configuration.user_agent_label})")
+
+      connection.basic_auth(configuration.username, configuration.password) if configuration.auth_type == 'basic_auth'
+      $lxca_log.info "XClarityClient::XclarityBase connection_builder", "Connection created Successfuly"
+
+      connection
+    end
+  end
+end

--- a/lib/xclarity_client/services/mixins/endpoint_manager_mixin.rb
+++ b/lib/xclarity_client/services/mixins/endpoint_manager_mixin.rb
@@ -1,0 +1,30 @@
+require 'xclarity_client/endpoints/xclarity_endpoint'
+
+module XClarityClient
+  module Services
+    #
+    # An Endpoint Manager must regist what endpoint it is managing
+    # to do that, just need to call #manages_endpoint method and
+    # pass as param the class that represents the endpoint (must be
+    # a subclass of XClarityEndpoint).
+    #
+    # @see XClarityClient::Endpoints::XClarityEndpoint
+    #
+    module EndpointManagerMixin
+
+      private
+
+      #
+      # Sets which endpoint is managed by the service
+      #
+      # @param [Class] - Class that represents some endpoind
+      # @see XClarityClient::Endpoints::XClarityEndpoint
+      #
+      def manages_endpoint(endpoint_class)
+        raise ArgumentError, "The class #{endpoint_class.name} isn't a subclass of XClarityEndpoint" unless endpoint_class < Endpoints::XclarityEndpoint
+
+        define_method(:managed_resource) { endpoint_class }
+      end
+    end
+  end
+end

--- a/lib/xclarity_client/services/mixins/list_name_interpreter_mixin.rb
+++ b/lib/xclarity_client/services/mixins/list_name_interpreter_mixin.rb
@@ -1,0 +1,61 @@
+module XClarityClient
+  module Services
+    #
+    # A list name interpreter knows how to get the correct
+    # list name present on endpoint response, and, if the list
+    # doesn't exist, add the list property to the reponse with
+    # the right name.
+    #
+    module ListNameInterpreterMixin
+      #
+      # Process the response body to make sure that its contains the list name defined on resource
+      #
+      # @return the list name present on body and the body itself
+      #
+      def add_listname_on_body(endpoint_class, body)
+        body.kind_of?(Array) ? process_body_as_array(endpoint_class, body) : process_body_as_hash(endpoint_class, body)
+      end
+
+      private
+
+      #
+      # @return any listname described on resource
+      #
+      def any_listname_of(endpoint_class)
+        if endpoint_class::LIST_NAME.kind_of?(Array)
+          endpoint_class::LIST_NAME.first # If is an array, any listname can be use
+        else
+          endpoint_class::LIST_NAME # If is not an array, just return the listname of resource
+        end
+      end
+
+      #
+      # @return the body value assigned to the list name defined on resource
+      #
+      def process_body_as_array(endpoint_class, body)
+        list_name = any_listname_of(endpoint_class)
+
+        return list_name, { list_name => body } # assign the list name to the body
+      end
+
+      #
+      # Discover what list name defined on resource is present on body
+      # If none of then is find assume that the body is a single resource
+      # and add it value into array and assing to any list name
+      #
+      # @return the list name present on body and the body itself
+      #
+      def process_body_as_hash(endpoint_class, body)
+        result = body
+
+        if endpoint_class::LIST_NAME.kind_of? Array # search which list name is present on body
+          list_name = endpoint_class::LIST_NAME.find { |name| body.keys.include?(name) && body[name].kind_of?(Array) }
+        else
+          list_name = any_listname_of(endpoint_class)
+        end
+        result = {list_name => [body]} unless body.has_key? list_name # for the cases where body represents a single resource
+        return list_name, result
+      end
+    end
+  end
+end

--- a/lib/xclarity_client/services/mixins/response_builder_mixin.rb
+++ b/lib/xclarity_client/services/mixins/response_builder_mixin.rb
@@ -1,0 +1,38 @@
+require 'xclarity_client/services/mixins/list_name_interpreter_mixin'
+
+module XClarityClient
+  module Services
+    #
+    # A response builder knows how to treat a response from LXCA
+    # and create a ruby response
+    #
+    module ResponseBuilderMixin
+      include ListNameInterpreterMixin
+
+      #
+      # Builds an array from an LXCA response that contains
+      # a list of resources.
+      #
+      # @param response       - the LXCA response
+      # @param endpoint_class - the class that represents the endpoint that generates the response
+      #
+      # @return [Array] containing the resources of the LXCA response
+      #
+      def build_response_with_resource_list(response, endpoint_class)
+        return [] unless response.success?
+
+        body = JSON.parse(response.body)
+
+        if endpoint_class == XClarityClient::User
+          body = body['response']
+        end
+
+        list_name, body = add_listname_on_body(endpoint_class, body)
+
+        body[list_name].map do |resource_params|
+          endpoint_class.new resource_params
+        end
+      end
+    end
+  end
+end

--- a/lib/xclarity_client/services/xclarity_service.rb
+++ b/lib/xclarity_client/services/xclarity_service.rb
@@ -1,0 +1,139 @@
+require 'xclarity_client/connection/connection'
+require 'xclarity_client/services/mixins/response_builder_mixin'
+require 'xclarity_client/services/mixins/endpoint_manager_mixin'
+
+module XClarityClient
+  module Services
+    class XClarityService
+      include ResponseBuilderMixin
+      extend  EndpointManagerMixin
+
+      def initialize(connection_conf)
+        @connection = XClarityClient::Connection.new(connection_conf)
+      end
+
+      #
+      # Fetchs all resources represented by `managed_resource` from LXCA
+      #
+      # @return [Array] containing all `managed_resource` from LXCA
+      # @see EndpointManagerMixin#managed_resource
+      #
+      def fetch_all(opts = {})
+        $lxca_log.info "XclarityClient::Endpoints::XClarityService fetch_all",
+                       "Sending request to #{managed_resource} resource"
+
+        response = @connection.do_get(managed_resource::BASE_URI, opts)
+
+        $lxca_log.info "XclarityClient::Endpoints::XClarityService fetch_all",
+                       "Response received from #{managed_resource::BASE_URI}"
+
+        build_response_with_resource_list(response, managed_resource)
+      end
+
+      def get_object(uuids, includeAttributes, excludeAttributes)
+        $lxca_log.info "XclarityClient::Endpoints::XClarityService get_object",
+                       "Sending request to #{managed_resource} resource"
+
+        uuids.reject! { |uuid| UUID.validate(uuid).nil? } unless uuids.nil?
+
+        response = if not includeAttributes.nil?
+          get_object_with_include_attributes(uuids, includeAttributes)
+        elsif not excludeAttributes.nil?
+          get_object_with_exclude_attributes(uuids, excludeAttributes)
+        elsif not uuids.nil?
+          @connection.do_get(managed_resource::BASE_URI + "/" + uuids.join(","))
+        else
+          @connection.do_get(managed_resource::BASE_URI)
+        end
+
+        build_response_with_resource_list(response, managed_resource)
+      end
+
+      def get_object_with_id(ids, includeAttributes, excludeAttributes)
+        response = if not includeAttributes.nil?
+          get_object_with_id_include_attributes(ids, includeAttributes, managed_resource)
+        elsif not excludeAttributes.nil?
+          get_object_with_id_exclude_attributes(ids, excludeAttributes, managed_resource)
+        elsif not ids.nil?
+          @connection.do_get(managed_resource::BASE_URI + "/" + ids.join(","))
+        else
+          @connection.do_get(managed_resource::BASE_URI)
+        end
+
+        build_response_with_resource_list(response, managed_resource)
+      end
+
+      def get_object_with_opts(opts, resource)
+        raise "The opts cannot be empty" if opts.empty?
+        filter = ""
+
+        response = if not opts.empty?
+          if not opts.has_key? "type"
+            if opts.has_key? "filterWith"
+              filter += "?filterWith="
+              filter += "#{opts["filterWith"]}"
+
+            elsif opts.has_key? "sort"
+              filter += ",sort=" if filter != ""
+              filter += "?sort=" if filter == ""
+              filter += "#{opts["sort"]}"
+            end
+          else
+            filter += "?type=#{opts["type"]}"
+          end
+        $lxca_log.info "XclarityClient::ManagementMixin get_object_with_include", "Sending request to #{resource} resource using the following filter: #{filter}"
+        @connection.do_get(resource::BASE_URI + filter)
+        end
+
+        build_response_with_resource_list(response, managed_resource)
+      end
+
+      private
+
+      #
+      #
+      #
+      def get_object_with_include_attributes(uuids, attributes)
+        $lxca_log.info "XclarityClient::ManagementMixin get_object_with_include",
+                       "Sending request to #{managed_resource} resource including the following attributes: #{attributes.join(",")}"
+
+        response = if not uuids.nil?
+          @connection.do_get(managed_resource::BASE_URI + "/" + uuids.join(",") + "?includeAttributes=" + attributes.join(","))
+        else
+          @connection.do_get(managed_resource::BASE_URI + "?includeAttributes=" + attributes.join(","))
+        end
+
+      end
+
+      #
+      #
+      #
+      def get_object_with_exclude_attributes(uuids, attributes)
+        $lxca_log.info "XclarityClient::ManagementMixin get_object_with_include",
+                       "Sending request to #{managed_resource} resource excluding the following attributes: #{attributes.join(",")}"
+
+        response = if not uuids.nil?
+          @connection.do_get(managed_resource::BASE_URI + "/#{uuids.join(",")}"+"?excludeAttributes=#{attributes.join(",")}")
+        else
+          @connection.do_get(managed_resource::BASE_URI + "?excludeAttributes=" + attributes.join(","))
+        end
+      end
+
+      def get_object_with_id_include_attributes(uuids, attributes, resource)
+        response = if not uuids.nil?
+          @connection.do_get(resource::BASE_URI + "/" + uuids.join(",") + "?includeAttributes=" + attributes.join(","))
+        else
+          @connection.do_get(resource::BASE_URI + "?includeAttributes=" + attributes.join(","))
+        end
+      end
+
+      def get_object_with_id_exclude_attributes(uuids, attributes, resource)
+        response = if not uuids.nil?
+          @connection.do_get(resource::BASE_URI + "/#{uuids.join(",")}"+"?excludeAttributes=#{attributes.join(",")}")
+        else
+          @connection.do_get(resource::BASE_URI + "?excludeAttributes=" + attributes.join(","))
+        end
+      end
+    end
+  end
+end

--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -31,7 +31,7 @@ module XClarityClient
         faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
         faraday.ssl[:verify] = conf.verify_ssl == 'PEER'
       end
-      
+
       @conn.headers[:user_agent] = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (conf.user_agent_label.nil? ? "" : " (#{conf.user_agent_label})")
       @conn.basic_auth(conf.username, conf.password) if conf.auth_type == 'basic_auth'
       $lxca_log.info "XClarityClient::XclarityBase connection_builder", "Connection created Successfuly"


### PR DESCRIPTION
__This PR is able to:__
- Add `XClarityClient::Services::XClarityService` to centralize some common operations of the services;
- Create `XClarityClient::Services::ResponseBuilderMixin` and `XClarityClient::Services::ListNameInterpreterMixin` to split some concerns of the `XClarityService`.

__Goal:__
- The main goal is make all services classes extend `XClarityService` centralizing the common operations, just needing to implement on sub classes the specific behaviors;
- Improve the code organization and promote a more cohesive structure.

__Depends on:__
https://github.com/lenovo/xclarity_client/pull/91
https://github.com/lenovo/xclarity_client/pull/94