### PR TITLE
Using the Abstract Service Class in all Management Classes

### DIFF
--- a/lib/xclarity_client.rb
+++ b/lib/xclarity_client.rb
@@ -9,11 +9,18 @@ require 'xclarity_client/errors/errors'
 
 require 'xclarity_client/configuration'
 require 'xclarity_client/xclarity_base'
+<<<<<<< 30d841cc83ac234d10ff746f6d7a510990c1b7ce
+=======
+require 'xclarity_client/xclarity_resource'
+>>>>>>> Creating abstract service
 require 'xclarity_client/xclarity_power_management_mixin'
 require 'xclarity_client/xclarity_credentials_validator'
 require 'xclarity_client/discover'
 require 'xclarity_client/client'
+<<<<<<< 30d841cc83ac234d10ff746f6d7a510990c1b7ce
 require 'xclarity_client/schemas'
+=======
+>>>>>>> Creating abstract service
 
 require 'xclarity_client/endpoints/endpoints'
 require 'xclarity_client/services/services'

--- a/lib/xclarity_client.rb
+++ b/lib/xclarity_client.rb
@@ -9,18 +9,11 @@ require 'xclarity_client/errors/errors'
 
 require 'xclarity_client/configuration'
 require 'xclarity_client/xclarity_base'
-<<<<<<< 30d841cc83ac234d10ff746f6d7a510990c1b7ce
-=======
-require 'xclarity_client/xclarity_resource'
->>>>>>> Creating abstract service
 require 'xclarity_client/xclarity_power_management_mixin'
 require 'xclarity_client/xclarity_credentials_validator'
 require 'xclarity_client/discover'
 require 'xclarity_client/client'
-<<<<<<< 30d841cc83ac234d10ff746f6d7a510990c1b7ce
 require 'xclarity_client/schemas'
-=======
->>>>>>> Creating abstract service
 
 require 'xclarity_client/endpoints/endpoints'
 require 'xclarity_client/services/services'

--- a/lib/xclarity_client/client.rb
+++ b/lib/xclarity_client/client.rb
@@ -27,8 +27,7 @@ module XClarityClient
                       excludeAttributes = nil)
       CabinetManagement.new(@connection).get_object(uuids,
                                                     includeAttributes,
-                                                    excludeAttributes,
-                                                    Cabinet)
+                                                    excludeAttributes)
     end
 
     def discover_canisters(opts = {})
@@ -40,8 +39,7 @@ module XClarityClient
                         excludeAttributes = nil)
       CanisterManagement.new(@connection).get_object(uuids,
                                                      includeAttributes,
-                                                     excludeAttributes,
-                                                     Canister)
+                                                     excludeAttributes)
     end
 
     def discover_cmms(opts = {})
@@ -53,8 +51,7 @@ module XClarityClient
                    excludeAttributes = nil)
       CmmManagement.new(@connection).get_object(uuids,
                                                 includeAttributes,
-                                                excludeAttributes,
-                                                Cmm)
+                                                excludeAttributes)
     end
 
     def fetch_fans(uuids = nil,
@@ -62,8 +59,7 @@ module XClarityClient
                    excludeAttributes = nil)
       FanManagement.new(@connection).get_object(uuids,
                                                 includeAttributes,
-                                                excludeAttributes,
-                                                Fan)
+                                                excludeAttributes)
     end
 
     def discover_fans(opts = {})
@@ -83,8 +79,7 @@ module XClarityClient
                         excludeAttributes = nil)
       FanMuxManagement.new(@connection).get_object(uuids,
                                                    includeAttributes,
-                                                   excludeAttributes,
-                                                   FanMux)
+                                                   excludeAttributes)
     end
 
     def discover_chassis(opts = {})
@@ -100,8 +95,7 @@ module XClarityClient
                     excludeAttributes = nil)
       NodeManagement.new(@connection).get_object(uuids,
                                                  includeAttributes,
-                                                 excludeAttributes,
-                                                 Node)
+                                                 excludeAttributes)
     end
 
     def fetch_chassis(uuids = nil,
@@ -109,8 +103,7 @@ module XClarityClient
                       excludeAttributes = nil)
       ChassiManagement.new(@connection).get_object(uuids,
                                                    includeAttributes,
-                                                   excludeAttributes,
-                                                   Chassi)
+                                                   excludeAttributes)
     end
 
     def fetch_scalableComplexes(uuids = nil,
@@ -118,8 +111,7 @@ module XClarityClient
                                 excludeAttributes = nil)
       ScalableComplexManagement.new(@connection).get_object(uuids,
                                                             includeAttributes,
-                                                            excludeAttributes,
-                                                            ScalableComplex)
+                                                            excludeAttributes)
     end
 
     def fetch_switches(uuids = nil,
@@ -127,8 +119,7 @@ module XClarityClient
                        excludeAttributes = nil)
       SwitchManagement.new(@connection).get_object(uuids,
                                                    includeAttributes,
-                                                   excludeAttributes,
-                                                   Switch)
+                                                   excludeAttributes)
     end
 
     def fetch_power_supplies(uuids = nil,
@@ -136,8 +127,7 @@ module XClarityClient
                              excludeAttributes = nil)
       PowerSupplyManagement.new(@connection).get_object(uuids,
                                                         includeAttributes,
-                                                        excludeAttributes,
-                                                        PowerSupply)
+                                                        excludeAttributes)
     end
 
     def discover_events
@@ -165,8 +155,7 @@ module XClarityClient
                    excludeAttributes = nil)
       FfdcManagement.new(@connection).get_object(uuids,
                                                 includeAttributes,
-                                                excludeAttributes,
-                                                Ffdc)
+                                                excludeAttributes)
     end
 
     def discover_jobs(opts = {})
@@ -178,8 +167,7 @@ module XClarityClient
                    excludeAttributes = nil)
       JobManagement.new(@connection).get_object_with_id(ids,
                                                 includeAttributes,
-                                                excludeAttributes,
-                                                Job)
+                                                excludeAttributes)
     end
 
     def cancel_job(id = '')
@@ -207,8 +195,7 @@ module XClarityClient
                    excludeAttributes = nil)
       UserManagement.new(@connection).get_object_with_id(ids,
                                                 includeAttributes,
-                                                excludeAttributes,
-                                                User)
+                                                excludeAttributes)
     end
 
     def change_user_password(current_password, new_password)
@@ -220,8 +207,7 @@ module XClarityClient
                    excludeAttributes = nil)
       ConfigTargetManagement.new(@connection).get_object_with_id(ids,
                                                         includeAttributes,
-                                                        excludeAttributes,
-                                                        ConfigTarget)
+                                                        excludeAttributes)
     end
 
     def fetch_config_profile(ids=nil,
@@ -229,8 +215,7 @@ module XClarityClient
                    excludeAttributes = nil)
       ConfigProfileManagement.new(@connection).get_object_with_id(ids,
                                                         includeAttributes,
-                                                        excludeAttributes,
-                                                        ConfigProfile)
+                                                        excludeAttributes)
     end
 
     def discover_config_profile
@@ -264,8 +249,7 @@ module XClarityClient
                    excludeAttributes = nil)
       ConfigPatternManagement.new(@connection).get_object_with_id(ids,
                                                         includeAttributes,
-                                                        excludeAttributes,
-                                                        ConfigPattern)
+                                                        excludeAttributes)
     end
 
     def discover_config_pattern

--- a/lib/xclarity_client/services/aicc_management.rb
+++ b/lib/xclarity_client/services/aicc_management.rb
@@ -1,16 +1,9 @@
-# XClarityClient module/namespace
 module XClarityClient
-  # Aicc Management class
-  class AiccManagement < XClarityBase
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Aicc::BASE_URI)
-    end
+  class AiccManagement < Services::XClarityService
+    manages_endpoint Aicc
 
     def population(opts = {})
-      get_all_resources(Aicc, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/cabinet_management.rb
+++ b/lib/xclarity_client/services/cabinet_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class CabinetManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Cabinet::BASE_URI)
-    end
+  class CabinetManagement < Services::XClarityService
+    manages_endpoint Cabinet
 
     def population(opts = {})
-      get_all_resources(Cabinet, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/canister_management.rb
+++ b/lib/xclarity_client/services/canister_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class CanisterManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Canister::BASE_URI)
-    end
+  class CanisterManagement < Services::XClarityService
+    manages_endpoint Canister
 
     def population(opts = {})
-      get_all_resources(Canister, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/chassi_management.rb
+++ b/lib/xclarity_client/services/chassi_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class ChassiManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Chassi::BASE_URI)
-    end
+  class ChassiManagement < Services::XClarityService
+    manages_endpoint Chassi
 
     def population(opts = {})
-      get_all_resources(Chassi, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/cmm_management.rb
+++ b/lib/xclarity_client/services/cmm_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class CmmManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Cmm::BASE_URI)
-    end
+  class CmmManagement < Services::XClarityService
+    manages_endpoint Cmm
 
     def population(opts = {})
-      get_all_resources(Cmm, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/config_pattern_management.rb
+++ b/lib/xclarity_client/services/config_pattern_management.rb
@@ -1,28 +1,23 @@
 require 'json'
 
 module XClarityClient
-  class ConfigPatternManagement < XClarityBase
+  class ConfigPatternManagement < Services::XClarityService
+    manages_endpoint ConfigPattern
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, ConfigPattern::BASE_URI)
-    end
-
-    def population()
-      get_all_resources(ConfigPattern)
+    def population(opts = {})
+      fetch_all(opts)
     end
 
     def export(id)
-      response = connection(ConfigPattern::BASE_URI + "/" + id + "/includeSettings" )      
+      response = @connection.do_get(managed_resource::BASE_URI + "/" + id + "/includeSettings" )
       return [] unless response.success?
 
       body = JSON.parse(response.body)
 
-      body = {ConfigPattern::LIST_NAME => body} if body.is_a? Array
-      body = {ConfigPattern::LIST_NAME => [body]} unless body.has_key? ConfigPattern::LIST_NAME
-      body[ConfigPattern::LIST_NAME].map do |resource_params|
-        ConfigPattern.new resource_params
+      body = {managed_resource::LIST_NAME => body} if body.is_a? Array
+      body = {managed_resource::LIST_NAME => [body]} unless body.has_key? managed_resource::LIST_NAME
+      body[managed_resource::LIST_NAME].map do |resource_params|
+        managed_resource.new resource_params
       end
     end
 
@@ -33,16 +28,14 @@ module XClarityClient
         deployHash = {:endpointIds => endpoints}
       end
       deployHash.merge!({:restart => restart})
-      response = do_post(ConfigPattern::BASE_URI + '/' +id, JSON.generate(deployHash))
+      response = @connection.do_post(managed_resource::BASE_URI + '/' +id, JSON.generate(deployHash))
       response
 
     end
 
     def import_config_pattern(config_pattern)
-      response = do_post(ConfigPattern::BASE_URI, config_pattern)
+      response = @connection.do_post(managed_resource::BASE_URI, config_pattern)
       response
     end
-
   end
 end
-

--- a/lib/xclarity_client/services/config_profile_management.rb
+++ b/lib/xclarity_client/services/config_profile_management.rb
@@ -1,41 +1,35 @@
 require 'json'
 
 module XClarityClient
-  class ConfigProfileManagement < XClarityBase
+  class ConfigProfileManagement < Services::XClarityService
+    manages_endpoint ConfigProfile
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, ConfigProfile::BASE_URI)
-    end
-
-    def population()
-      get_all_resources(ConfigProfile)
+    def population(opts = {})
+      fetch_all(opts)
     end
 
     def rename_config_profile(id='', name='')
       renameReq = JSON.generate(profileName: name)
-      response = do_put(ConfigProfile::BASE_URI + '/' +id, renameReq)
+      response = @connection.do_put(managed_resource::BASE_URI + '/' +id, renameReq)
       response
     end
 
     def activate_config_profile(id='', endpoint_uuid='', restart='')
       postReq = JSON.generate(restart: restart, uuid: endpoint_uuid)
-      response = do_post(ConfigProfile::BASE_URI + '/' +id, postReq)
+      response = @connection.do_post(managed_resource::BASE_URI + '/' +id, postReq)
       response
     end
 
     def unassign_config_profile(id='', force='',powerDown='',resetImm='')
       unassignReq = JSON.generate(force: force, powerDownITE: powerDown, resetIMM: resetImm)
-      response = do_post(ConfigProfile::BASE_URI + '/unassign/' +id, unassignReq)
+      response = @connection.do_post(managed_resource::BASE_URI + '/unassign/' +id, unassignReq)
       response
     end
 
     def delete_config_profile(id='')
-      response = do_delete(ConfigProfile::BASE_URI + '/' + id)
+      response = @connection.do_delete(managed_resource::BASE_URI + '/' + id)
       response
     end
-
   end
 end
 

--- a/lib/xclarity_client/services/config_target_management.rb
+++ b/lib/xclarity_client/services/config_target_management.rb
@@ -1,14 +1,9 @@
-require 'json'
-require 'uuid'
-
 module XClarityClient
-  class ConfigTargetManagement < XClarityBase
-    include XClarityClient::ManagementMixin
+  class ConfigTargetManagement < Services::XClarityService
+    manages_endpoint ConfigTarget
 
-    def initialize(conf)
-      super(conf, ConfigTarget::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
-
   end
 end
-

--- a/lib/xclarity_client/services/discover_request_management.rb
+++ b/lib/xclarity_client/services/discover_request_management.rb
@@ -1,32 +1,30 @@
 require 'json'
 
 module XClarityClient
-  class DiscoverRequestManagement < XClarityBase
+  class DiscoverRequestManagement < Services::XClarityService
+    manages_endpoint DiscoverRequest
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, DiscoverRequest::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
 
     def discover_manageable_devices(ip_addresses)
       post_req = JSON.generate([ipAddresses: ip_addresses])
-      response = do_post(DiscoverRequest::BASE_URI, post_req)
+      response = @connection.do_post(managed_resource::BASE_URI, post_req)
       response
     end
 
     def monitor_discover_request(job_id)
-      response = connection(DiscoverRequest::BASE_URI + "/jobs/" + job_id)
+      response = @connection.do_get(managed_resource::BASE_URI + "/jobs/" + job_id)
       return [] unless response.success?
 
       body = JSON.parse(response.body)
 
-      body = {DiscoverRequest::LIST_NAME => body} if body.is_a? Array
-      body = {DiscoverRequest::LIST_NAME => [body]} unless body.has_key? DiscoverRequest::LIST_NAME
-      body[DiscoverRequest::LIST_NAME].map do |resource_params|
-        DiscoverRequest.new resource_params
+      body = {managed_resource::LIST_NAME => body} if body.is_a? Array
+      body = {managed_resource::LIST_NAME => [body]} unless body.has_key? managed_resource::LIST_NAME
+      body[managed_resource::LIST_NAME].map do |resource_params|
+        managed_resource.new resource_params
       end
     end
-
   end
 end

--- a/lib/xclarity_client/services/discovery_management.rb
+++ b/lib/xclarity_client/services/discovery_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class DiscoveryManagement < XClarityBase
+  class DiscoveryManagement  < Services::XClarityService
+    manages_endpoint Discovery
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Discovery::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
-
-    def population()
-      get_all_resources(Discovery)
-    end
-
   end
 end

--- a/lib/xclarity_client/services/event_management.rb
+++ b/lib/xclarity_client/services/event_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class EventManagement < XClarityBase
+  class EventManagement < Services::XClarityService
+    manages_endpoint Event
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Event::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
-
-    def population
-      get_all_resources(Event)
-    end
-
   end
 end

--- a/lib/xclarity_client/services/fan_management.rb
+++ b/lib/xclarity_client/services/fan_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class FanManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Fan::BASE_URI)
-    end
+  class FanManagement < Services::XClarityService
+    manages_endpoint Fan
 
     def population(opts = {})
-      get_all_resources(Fan, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/fan_mux_management.rb
+++ b/lib/xclarity_client/services/fan_mux_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class FanMuxManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, FanMux::BASE_URI)
-    end
+  class FanMuxManagement < Services::XClarityService
+    manages_endpoint FanMux
 
     def population(opts = {})
-      get_all_resources(FanMux, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/ffdc_management.rb
+++ b/lib/xclarity_client/services/ffdc_management.rb
@@ -1,13 +1,9 @@
-require 'json'
-require 'uuid'
-
 module XClarityClient
-  class FfdcManagement < XClarityBase
-    include XClarityClient::ManagementMixin
+  class FfdcManagement  < Services::XClarityService
+    manages_endpoint Ffdc
 
-    def initialize(conf)
-      super(conf, Ffdc::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/job_management.rb
+++ b/lib/xclarity_client/services/job_management.rb
@@ -1,26 +1,21 @@
 require 'json'
 
 module XClarityClient
-  class JobManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Job::BASE_URI)
-    end
+  class JobManagement < Services::XClarityService
+    manages_endpoint Job
 
     def population(opts = {})
-      get_all_resources(Job, opts)
+      fetch_all(opts)
     end
 
     def cancel_job(uuid='')
       cancelReq = JSON.generate(cancelRequest: 'true')
-      response = do_put(Job::BASE_URI + '/' + uuid, cancelReq)
+      response = @connection.do_put(managed_resource::BASE_URI + '/' + uuid, cancelReq)
       response
     end
 
     def delete_job(uuid='')
-      response = do_delete(Job::BASE_URI + '/' + uuid)
+      response = @connection.do_delete(managed_resource::BASE_URI + '/' + uuid)
       response
     end
 
@@ -28,6 +23,5 @@ module XClarityClient
       response = connection(Job::BASE_URI + '/' + job_id)
       response = JSON.parse(response.body)
     end
-
   end
 end

--- a/lib/xclarity_client/services/node_management.rb
+++ b/lib/xclarity_client/services/node_management.rb
@@ -4,15 +4,11 @@ require 'uuid'
 # XClarityClient module/namespace
 module XClarityClient
   # Node Management class
-  class NodeManagement < XClarityBase
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Node::BASE_URI)
-    end
+  class NodeManagement < Services::XClarityService
+    manages_endpoint Node
 
     def population(opts = {})
-      get_all_resources(Node, opts)
+      fetch_all(opts)
     end
 
     def set_node_power_state(uuid, requested_state = nil)
@@ -23,7 +19,7 @@ module XClarityClient
         raise ArgumentError, error
       end
 
-      send_power_request(Node::BASE_URI + '/' + uuid, requested_state)
+      send_power_request(managed_resource::BASE_URI + '/' + uuid, requested_state)
     end
 
     def set_bmc_power_state(uuid, requested_state = nil)
@@ -34,7 +30,7 @@ module XClarityClient
         raise ArgumentError, error
       end
 
-      send_power_request(Node::BASE_URI + '/' + uuid + '/bmc', requested_state)
+      send_power_request(managed_resource::BASE_URI + '/' + uuid + '/bmc', requested_state)
     end
 
     def set_loc_led_state(uuid, state, name = 'Identify')
@@ -42,14 +38,14 @@ module XClarityClient
 
       $lxca_log.info "XclarityClient::ManagementMixin set_loc_led_state", "Loc led state action has been sent"
 
-      do_put("#{Node::BASE_URI}/#{uuid}", request)
+      @connection.do_put("#{managed_resource::BASE_URI}/#{uuid}", request)
     end
 
     private
 
     def send_power_request(uri, requested_state = nil)
       power_request = JSON.generate(powerState: requested_state)
-      response = do_put(uri, power_request)
+      response = @connection.do_put(uri, power_request)
       msg = "Power state action has been sent with request #{power_request}"
 
       $lxca_log.info 'XclarityClient::NodeManagement set_node_power_state', msg

--- a/lib/xclarity_client/services/persisted_result_management.rb
+++ b/lib/xclarity_client/services/persisted_result_management.rb
@@ -1,16 +1,11 @@
 require 'json'
 
 module XClarityClient
-  class PersistedResultManagement < XClarityBase
+  class PersistedResultManagement < Services::XClarityService
+    manages_endpoint PersistedResult
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, PersistedResult::BASE_URI)
-    end
-
-    def population
-      get_all_resources(PersistedResult)
+    def population(opts = {})
+      fetch_all(opts)
     end
   end
 end

--- a/lib/xclarity_client/services/power_supply_management.rb
+++ b/lib/xclarity_client/services/power_supply_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class PowerSupplyManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, PowerSupply::BASE_URI)
-    end
+  class PowerSupplyManagement< Services::XClarityService
+    manages_endpoint PowerSupply
 
     def population(opts = {})
-      get_all_resources(PowerSupply, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/scalable_complex_management.rb
+++ b/lib/xclarity_client/services/scalable_complex_management.rb
@@ -1,17 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class ScalableComplexManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, ScalableComplex::BASE_URI)
-    end
+  class ScalableComplexManagement< Services::XClarityService
+    manages_endpoint ScalableComplex
 
     def population(opts = {})
-      get_all_resources(ScalableComplex, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/services.rb
+++ b/lib/xclarity_client/services/services.rb
@@ -4,6 +4,7 @@ module XClarityClient
 end
 
 require 'xclarity_client/services/xclarity_management_mixin'
+require 'xclarity_client/services/xclarity_service'
 
 require 'xclarity_client/services/aicc_management'
 require 'xclarity_client/services/cabinet_management'

--- a/lib/xclarity_client/services/switch_management.rb
+++ b/lib/xclarity_client/services/switch_management.rb
@@ -1,16 +1,9 @@
-require 'json'
-
 module XClarityClient
-  class SwitchManagement < XClarityBase
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, Switch::BASE_URI)
-    end
+  class SwitchManagement< Services::XClarityService
+    manages_endpoint Switch
 
     def population(opts = {})
-      get_all_resources(Switch, opts)
+      fetch_all(opts)
     end
-
   end
 end

--- a/lib/xclarity_client/services/unmanage_request_management.rb
+++ b/lib/xclarity_client/services/unmanage_request_management.rb
@@ -1,41 +1,38 @@
 require 'json'
 
 module XClarityClient
-  class UnmanageRequestManagement < XClarityBase
+  class UnmanageRequestManagement< Services::XClarityService
+    manages_endpoint UnmanageRequest
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      @conf = conf
-      super(conf, UnmanageRequest::BASE_URI)
+    def population(opts = {})
+      fetch_all(opts)
     end
 
     def unmanage_discovered_devices(endpoints, force)
       deploy_hash = {}
-      deploy_hash.merge!({:endpoints => endpoints})  
+      deploy_hash.merge!({:endpoints => endpoints})
       if force.downcase.eql? "true"
         deploy_hash.merge!({:forceUnmanage => true})
       else
          deploy_hash.merge!({:forceUnmanage => false})
-      end
-      response = do_post(UnmanageRequest::BASE_URI, JSON.generate(deploy_hash))
+        end
+        response = @connection.do_post(managed_resource::BASE_URI, JSON.generate(deploy_hash))
       if response.status == 200 or response.status == 201
         puts response.headers[:location].split("/")[-1]
       end
     end
 
     def fetch_unmanage_request(job_id)
-      response = connection(UnmanageRequest::BASE_URI + "/jobs/" + job_id)
+      response = @connection.do_get(managed_resource::BASE_URI + "/jobs/" + job_id)
       return [] unless response.success?
 
       body = JSON.parse(response.body)
 
-      body = {UnmanageRequest::LIST_NAME => body} if body.is_a? Array
-      body = {UnmanageRequest::LIST_NAME => [body]} unless body.has_key? UnmanageRequest::LIST_NAME
-      body[UnmanageRequest::LIST_NAME].map do |resource_params|
-        UnmanageRequest.new resource_params
+      body = {managed_resource::LIST_NAME => body} if body.is_a? Array
+      body = {managed_resource::LIST_NAME => [body]} unless body.has_key? managed_resource::LIST_NAME
+      body[managed_resource::LIST_NAME].map do |resource_params|
+        managed_resource.new resource_params
       end
     end
-
   end
 end

--- a/lib/xclarity_client/services/update_repo_management.rb
+++ b/lib/xclarity_client/services/update_repo_management.rb
@@ -1,24 +1,16 @@
-require 'json'
-
 module XClarityClient
-  class UpdateRepoManagement < XClarityBase
-
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, UpdateRepo::BASE_URI)
-    end
+  class UpdateRepoManagement < Services::XClarityService
+    manages_endpoint UpdateRepo
 
     def population(opts = {})
       raise "Option key must be provided for update_repo resource" if opts.empty?
       raise "Option key must be provided for update_repo resource" if not (opts.has_key?(:key) || opts.has_key?("key"))
       repoKey = opts[:key] || opts["key"]
       if repoKey == "supportedMts" || repoKey == "size" || repoKey == "lastRefreshed" || repoKey == "importDir" || repoKey == "publicKeys" || repoKey == "updates" || repoKey == "updatesByMt" || repoKey == "updatesByMtByComp"
-        get_all_resources(UpdateRepo, opts)
-      else 
+        fetch_all(opts)
+      else
         raise "The value for option key should be one of these : supportedMts, lastRefreshed, size, importDir, publicKeys, updates, updatesByMt, updatesByMtByComp"
       end
     end
-
   end
 end

--- a/lib/xclarity_client/services/user_management.rb
+++ b/lib/xclarity_client/services/user_management.rb
@@ -1,16 +1,11 @@
 require 'json'
 
 module XClarityClient
-  class UserManagement < XClarityBase
+  class UserManagement < Services::XClarityService
+    manages_endpoint User
 
-    include XClarityClient::ManagementMixin
-
-    def initialize(conf)
-      super(conf, User::BASE_URI)
-    end
-
-    def population()
-      get_all_resources(User)
+    def population(opts = {})
+      fetch_all(opts)
     end
 
     def change_password(current_password, new_password)
@@ -22,7 +17,7 @@ module XClarityClient
 
       request_body = JSON.generate(payload)
 
-      response = do_put(User::SUB_URIS[:changePassword], request_body)
+      response = @connection.do_put(managed_resource::SUB_URIS[:changePassword], request_body)
 
       mount_response_change_password(response)
     end


### PR DESCRIPTION
__This PR is able to:__
- Remove the `XClarityClient::Endpoints::XclarityEndpoint` declarations on the methods calls in the `client.rb` file;
- Make all the management classes extend the `XClarityClient::Services::XClarityService` promoting a better reuse of common methods;
- Use the `@connection` to make requests to LXCA.

__Depends on:__
- ~https://github.com/lenovo/xclarity_client/pull/91~ - Merged
- ~https://github.com/lenovo/xclarity_client/pull/94~ - Merged
- ~https://github.com/lenovo/xclarity_client/pull/96~ - Merged