### PR TITLE
Fix remote console for latest 2.0.0 LXCA builds

### DIFF
--- a/lib/xclarity_client/services/remote_access_management.rb
+++ b/lib/xclarity_client/services/remote_access_management.rb
@@ -21,12 +21,12 @@ module XClarityClient
 
     private
 
-    SUPPORTED_MIME_TYPES = ['application/json', 'application/x-java-jnlp-file']
+    SUPPORTED_MIME_TYPES = ['application/*json', 'application/x-java-jnlp-file']
 
     def build_remote_access_object(connection)
       content_type = connection.headers['Content-Type']
       case content_type
-      when /application\/json/
+      when /application\/.*json/
         build_json_remote_access_object(connection.body)
       when /application\/x-java-jnlp-file/
         build_jnlp_remote_access_object(connection.body)

--- a/spec/xclarity_client_remote_control_spec.rb
+++ b/spec/xclarity_client_remote_control_spec.rb
@@ -28,6 +28,14 @@ describe XClarityClient do
       it { is_expected.to have_attributes(:type => :url, :resource => 'my_url') }
     end
 
+    context 'when the API responds with Content-Type application/com.lenovo.lxca-v2.0.0+json; charset=ISO-8859-1' do
+      before do
+        @req_stub.to_return(:body => {:url => 'my_url'}.to_json, :headers => { 'Content-Type' => 'application/com.lenovo.lxca-v2.0.0+json; charset=ISO-8859-1' })
+      end
+
+      it { is_expected.to have_attributes(:type => :url, :resource => 'my_url') }
+    end
+
     context 'when the API responds with Content-Type application/x-java-jnlp-file' do
       before do
         @req_stub.to_return(:body => '<my_jnlp></my_jnlp>', :headers => { 'Content-Type' => 'other;application/x-java-jnlp-file;other' })


### PR DESCRIPTION
The code was only recognizing application/json as a valid json
response. We needed to add a broader check to also accept
application/com.lenovo.lxca-v2.0.0+json, since this Content-Type is
returned for the latest 2.0.0 LXCA builds.
Makes it broader enough to accept any content type that begins with
'application/' and ends with 'json', so that it is more resilient to
possible LXCA changes in the future.