### PR TITLE
Upgrading travis RVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.4
+  - 2.3.6
 before_install: gem install bundler -v 1.11.2


### PR DESCRIPTION
__This PR is able to:__
- Update the version of the Ruby used by Travis;

This version is based on the lower one supported by ManageIQ travis.