### PR TITLE
Adding param for LED name on node LED actions

### DIFF
--- a/lib/xclarity_client/mixins/node_mixin.rb
+++ b/lib/xclarity_client/mixins/node_mixin.rb
@@ -17,16 +17,16 @@ module XClarityClient
       )
     end
 
-    def blink_loc_led(uuid = '')
-      node_management.set_loc_led_state(uuid, 'Blinking')
+    def blink_loc_led(uuid = '', name = 'Identify')
+      node_management.set_loc_led_state(uuid, 'Blinking', name)
     end
 
-    def turn_on_loc_led(uuid = '')
-      node_management.set_loc_led_state(uuid, 'On')
+    def turn_on_loc_led(uuid = '', name = 'Identify')
+      node_management.set_loc_led_state(uuid, 'On', name)
     end
 
-    def turn_off_loc_led(uuid = '')
-      node_management.set_loc_led_state(uuid, 'Off')
+    def turn_off_loc_led(uuid = '', name = 'Identify')
+      node_management.set_loc_led_state(uuid, 'Off', name)
     end
 
     def power_on_node(uuid = '')


### PR DESCRIPTION
__This PR is able to__
- Add Location LED name param for node LED actions;

Once that the Location LED name can vary for each node, the name is needed when try to perform such actions.

To provide compatibility with the gem clients, the default value was kept.