### PR TITLE
Add enclosure to Storage endpoint

### DIFF
--- a/docs/apib/storages.apib
+++ b/docs/apib/storages.apib
@@ -147,7 +147,54 @@ FORMAT: 1A
                   }
                ],
                "drives":[
-
+                  {
+                      "model": "ST9300653SS",
+                      "vendorName": "IBM-ESXS",
+                      "status": "Up",
+                      "location": "0.22",
+                      "serialNumber": "6XN43QX50000B349D4LY",
+                      "healthReason": "",
+                      "health": "OK",
+                      "type": "SAS",
+                      "healthRecommendation": "",
+                      "size": "300.0GB"
+                  },
+                  {
+                      "model": "ST9300605SS",
+                      "vendorName": "IBM-ESXS",
+                      "status": "Up",
+                      "location": "0.17",
+                      "serialNumber": "6XP5L6ZE0000B344HRZG",
+                      "healthReason": "",
+                      "health": "OK",
+                      "type": "SAS",
+                      "healthRecommendation": "",
+                      "size": "300.0GB"
+                  },
+                  {
+                      "model": "ST9300653SS",
+                      "vendorName": "IBM-ESXS",
+                      "status": "Up",
+                      "location": "0.23",
+                      "serialNumber": "6XN43QR90000B350B5G2",
+                      "healthReason": "A disk that was previously a member of a disk group has been detected.",
+                      "health": "Degraded",
+                      "type": "SAS",
+                      "healthRecommendation": "- If the associated disk group is offline or quarantined, contact technical support. Otherwise, clear the disk metadata to reuse the disk.",
+                      "size": "300.0GB"
+                  },
+                  {
+                      "model": "ST9300605SS",
+                      "vendorName": "IBM-ESXS",
+                      "status": "Up",
+                      "location": "0.16",
+                      "serialNumber": "6XP5L7QP0000B344HS0E",
+                      "healthReason": "",
+                      "health": "OK",
+                      "type": "SAS",
+                      "healthRecommendation": "",
+                      "size": "300.0GB"
+                  }
                ],
                "canisters":[
                   {

--- a/lib/xclarity_client/endpoints/storage.rb
+++ b/lib/xclarity_client/endpoints/storage.rb
@@ -10,9 +10,10 @@ module XClarityClient
     LIST_NAME = 'storageList'.freeze
 
     attr_accessor :uuid, :name, :type, :accessState, :cmmHealthState,
-                  :overallHealthState, :driveBays, :enclosureCount,
-                  :canisterSlots, :productName, :machineType, :model,
-                  :serialNumber, :contact, :description, :location,
-                  :room, :rack, :lowestRackUnit, :mgmtProcIPaddress
+                  :enclosures, :overallHealthState, :driveBays,
+                  :enclosureCount, :canisterSlots, :productName,
+                  :machineType, :model, :serialNumber, :contact,
+                  :description, :location, :room, :rack,
+                  :lowestRackUnit, :mgmtProcIPaddress
   end
 end

--- a/spec/xclarity_client_storage_spec.rb
+++ b/spec/xclarity_client_storage_spec.rb
@@ -34,12 +34,15 @@ describe XClarityClient do
 
     it 'correct response values' do
       storage = @storages[0]
+      enclosure_one = storage.enclosures.first
+
       expect(storage.name).to eq('S3200-1')
       expect(storage.type).to eq('Lenovo Storage')
       expect(storage.accessState).to eq('Online')
       expect(storage.driveBays).to eq(12)
       expect(storage.enclosureCount).to eq(1)
       expect(storage.canisterSlots).to eq(2)
+      expect(enclosure_one['drives'].count).to eq(4)
     end
   end
 


### PR DESCRIPTION
This PR is able to:
- Add an enclosure to Storage endpoint in order to enable get its data (like drivers, canisters, etc.)