### PR TITLE
Add support to request headers to XClarity connection

### DIFF
--- a/lib/xclarity_client/services/compliance_policy_management.rb
+++ b/lib/xclarity_client/services/compliance_policy_management.rb
@@ -17,10 +17,8 @@ module XClarityClient
     end
     
     def get_update_policy(uri, opts = {})
-      query = opts
-      response = @connection.do_get(uri, query)
-      build_response_with_resource_list(response, managed_resource)
-    end 
+      fetch_all(opts, uri)
+    end
 
     def assign_compliance_policy(opts = {}, keep, auto_assign)
       assign_hash = {:policyname => opts["policyname"], :type => opts["type"], :uuid => opts["uuid"]}
@@ -37,14 +35,14 @@ module XClarityClient
 
       assign_hash_str = assign_hash.to_json
       response = @connection.do_post(managed_resource::SUB_URIS[:compareResult], "{\"compliance\": [#{assign_hash_str}]}") 
-      puts response.body
+      response.body
     end
 
     def delete_compliance_policy(policy_name,removePackage)
       query = policy_name.nil? ? "" : "?policyName=" + policy_name
       query = removePackage.nil? ? query : query + "&removePackage=" + removePackage 
       response = @connection.do_delete(managed_resource::BASE_URI + query)
-      puts response.body
+      response.body
     end
 
   end

--- a/spec/xclarity_client_compliance_policy_spec.rb
+++ b/spec/xclarity_client_compliance_policy_spec.rb
@@ -60,7 +60,7 @@ describe XClarityClient do
         uri = "#{@host}/compliancePolicies/compareResult"
         assign_hash_str = opts.to_json
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
 
@@ -71,7 +71,7 @@ describe XClarityClient do
         uri = "#{@host}/compliancePolicies/compareResult"
         assign_hash_str = opts.to_json
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
 
@@ -82,7 +82,7 @@ describe XClarityClient do
         uri = "#{@host}/compliancePolicies/compareResult"
         assign_hash_str = opts.to_json
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made 
+        expect(a_request(:post, uri).with(:body => "{\"compliance\": [#{assign_hash_str}]}", :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made 
       end
     end
   end
@@ -93,7 +93,7 @@ describe XClarityClient do
         @client.delete_compliance_policy(@policy_name,"true")
         uri = "#{@host}/compliancePolicies?policyName=#{@policy_name}&removePackage=true"
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:delete, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:delete, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
 
@@ -102,7 +102,7 @@ describe XClarityClient do
         @client.delete_compliance_policy(@policy_name,"false")
         uri = "#{@host}/compliancePolicies?policyName=#{@policy_name}&removePackage=false"
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:delete, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:delete, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end

--- a/spec/xclarity_client_config_profile_spec.rb
+++ b/spec/xclarity_client_config_profile_spec.rb
@@ -117,7 +117,7 @@ describe XClarityClient do
         uri = "#{@host}/profiles/unassign/#{@idArray[0]}"
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
         puts user_agent
-        expect(a_request(:post, uri).with(:body => JSON.generate(force: 'False', powerDownITE: 'False', resetIMM: 'False'), :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=> user_agent})).to have_been_made
+        expect(a_request(:post, uri).with(:body => JSON.generate(force: 'False', powerDownITE: 'False', resetIMM: 'False'), :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=> user_agent})).to have_been_made
       end
     end
   end

--- a/spec/xclarity_client_discover_request_spec.rb
+++ b/spec/xclarity_client_discover_request_spec.rb
@@ -39,7 +39,7 @@ describe XClarityClient do
         @client.discover_manageable_devices(["1.2.3.4"])
         uri = "#{@host}/discoverRequest"
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-	expect(a_request(:post, uri).with(:body => '[{"ipAddresses":["1.2.3.4"]}]', :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+	expect(a_request(:post, uri).with(:body => '[{"ipAddresses":["1.2.3.4"]}]', :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end

--- a/spec/xclarity_client_update_repo_spec.rb
+++ b/spec/xclarity_client_update_repo_spec.rb
@@ -95,7 +95,7 @@ describe XClarityClient do
         @client.read_update_repo
         uri = "#{@host}/updateRepositories/firmware?action=read"
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:put, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made         
+        expect(a_request(:put, uri).with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made         
       end
     end
   end
@@ -114,7 +114,7 @@ describe XClarityClient do
 
         refresh_json = JSON.generate(mt: ["1234"], os: "", type: "catalog")
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:put, uri).with(:body => refresh_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:put, uri).with(:body => refresh_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end
@@ -133,7 +133,7 @@ describe XClarityClient do
 
         acquire_json = JSON.generate(mt: ["1234"], fixids: ["brcd_fw_bcsw_nos5.0.1_anyos_noarch"], type: "latest")
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:put, uri).with(:body => acquire_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:put, uri).with(:body => acquire_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end
@@ -152,7 +152,7 @@ describe XClarityClient do
 
         delete_json = JSON.generate(fixids: ["brcd_fw_bcsw_nos5.0.1_anyos_noarch"])
         user_agent = "LXCA via Ruby Client/#{XClarityClient::VERSION}" + (@user_agent.nil? ? "" : " (#{@user_agent})")
-        expect(a_request(:put, uri).with(:body => delete_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:put, uri).with(:body => delete_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end
@@ -172,7 +172,7 @@ describe XClarityClient do
         
         export_json = JSON.generate(fixids: ["brcd_fw_bcsw_nos5.0.1_anyos_noarch"])
 
-        expect(a_request(:put, uri).with(:body => export_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
+        expect(a_request(:put, uri).with(:body => export_json, :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip,deflate', 'Authorization'=>'Basic Og==', 'Content-Type'=>'application/json', 'User-Agent'=>user_agent})).to have_been_made
       end
     end
   end

--- a/xclarity_client.gemspec
+++ b/xclarity_client.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 2.1.0"
   spec.add_dependency             "faraday", "~> 0.9"
   spec.add_dependency             "faraday-cookie_jar", "~> 0.0.6"
+  spec.add_dependency             "httpclient", "~>2.8.3"
   spec.add_dependency             "uuid", "~> 2.3.8"
   spec.add_dependency             "faker", "~> 1.8.3"
   spec.add_dependency             "json-schema", "~> 2.8.0"


### PR DESCRIPTION
This PR is able to:
- Add support to passing headers in each connection request of Xclarity Client
- Change Faraday adaptor to use HTTPClient
- Fix problems with Compliance Policy Management (required due to the changes made on the GET requests)