### PR TITLE
Fixing Storage endpoint and adding Canisters on it

### DIFF
--- a/docs/apib/storages.apib
+++ b/docs/apib/storages.apib
@@ -2,7 +2,7 @@ FORMAT: 1A
 
 # Storages
 
-# GET /storages
+# GET /storage
 
 + Response 200 (application/json)
 {
@@ -483,7 +483,7 @@ FORMAT: 1A
 + Response 409
 + Response 500
 
-# GET /storages/1B33D6D13F267A614567A897DC784F00?includeAttributes=name,type,accessState,driveBays,enclosureCount,canisterSlots,room
+# GET /storage/1B33D6D13F267A614567A897DC784F00?includeAttributes=name,type,accessState,driveBays,enclosureCount,canisterSlots,room
 
 + Response 200 (application/json)
 {
@@ -506,7 +506,7 @@ FORMAT: 1A
 + Response 409
 + Response 500
 
-# GET /storages/1B33D6D13F267A614567A897DC784F00?excludeAttributes=type,room
+# GET /storage/1B33D6D13F267A614567A897DC784F00?excludeAttributes=type,room
 
 + Response 200 (application/json)
 {

--- a/lib/xclarity_client/endpoints/storage.rb
+++ b/lib/xclarity_client/endpoints/storage.rb
@@ -6,14 +6,15 @@ module XClarityClient
   # speed, security and high availability
   #
   class Storage < Endpoints::XclarityEndpoint
-    BASE_URI = '/storages'.freeze
+    BASE_URI = '/storage'.freeze
     LIST_NAME = 'storageList'.freeze
 
     attr_accessor :uuid, :name, :type, :accessState, :cmmHealthState,
-                  :enclosures, :overallHealthState, :driveBays,
-                  :enclosureCount, :canisterSlots, :productName,
-                  :machineType, :model, :serialNumber, :contact,
-                  :description, :location, :room, :rack,
-                  :lowestRackUnit, :mgmtProcIPaddress
+                  :enclosures, :canisters, :overallHealthState, :driveBays,
+                  :enclosureCount, :canisterSlots, :parent,
+                  :productName, :machineType, :model,
+                  :serialNumber, :contact, :description,
+                  :location, :room, :rack, :lowestRackUnit,
+                  :mgmtProcIPaddress
   end
 end


### PR DESCRIPTION
This PR is able to:
- Fix `/storage` endpoint
- Add Canisters to `/storage` in order to get this data if there is no enclosure on Storage