### PR TITLE
Update faraday to any version before January of '14

### DIFF
--- a/xclarity_client.gemspec
+++ b/xclarity_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "apib-mock_server", "~> 1.0.3"
   spec.add_development_dependency "webmock", "~> 2.1.0"
-  spec.add_dependency             "faraday", "~> 0.9"
+  spec.add_dependency             "faraday", '>= 0.9', '< 2.0.0'
   spec.add_dependency             "faraday-cookie_jar", "~> 0.0.6"
   spec.add_dependency             "httpclient", "~>2.8.3"
   spec.add_dependency             "uuid", "~> 2.3.8"


### PR DESCRIPTION
[Faraday got updated](https://github.com/lostisland/faraday/pull/1101) and [we over at manageiq](https://github.com/ManageIQ/manageiq/issues/19760) were hoping maybe that you all might be amenable to letting people update so we can support ruby 2.7.

This is a pretty significant change since 0.9 is from January of 2014. 

Specs greened on this, I'd be happy to fix the codeclimate if needed. 

Thanks!