### PR TITLE
Use faker in development not production

### DIFF
--- a/xclarity_client.gemspec
+++ b/xclarity_client.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "apib-mock_server", "~> 1.0.3"
   spec.add_development_dependency "webmock", "~> 2.1.0"
+  spec.add_development_dependency "faker", "~> 1.8.3"
   spec.add_dependency             "faraday", '>= 0.9', '< 2.0.0'
   spec.add_dependency             "faraday-cookie_jar", "~> 0.0.6"
   spec.add_dependency             "httpclient", "~>2.8.3"
   spec.add_dependency             "uuid", "~> 2.3.8"
-  spec.add_dependency             "faker", "~> 1.8.3"
   spec.add_dependency             "json-schema", "~> 2.8.0"
 end


### PR DESCRIPTION
Hi,

I'm trying to remove extra gem dependencies in our production.
It looks like you all use `faker` as a development dependency and not a runtime dependency.
Which makes sense. It is a testing helper.

This change allows you to develop using `faker`, but projects that depend upon your library to not bring it into their project.

Thanks for the gem.