### PR TITLE
Allow httpclient v2.9

### DIFF
--- a/xclarity_client.gemspec
+++ b/xclarity_client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faker", "~> 1.8.3"
   spec.add_dependency             "faraday", '>= 0.9', '< 2.0.0'
   spec.add_dependency             "faraday-cookie_jar", "~> 0.0.6"
-  spec.add_dependency             "httpclient", "~>2.8.3"
+  spec.add_dependency             "httpclient", "~> 2.8"
   spec.add_dependency             "uuid", "~> 2.3.8"
   spec.add_dependency             "json-schema", "~> 2.8.0"
 end


### PR DESCRIPTION
httpclient v2.9 is required for ruby 3.4 compatibility

https://github.com/ManageIQ/manageiq/issues/23688